### PR TITLE
Allow V8_DIR to be overridden for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ EXAMPLE_WAT = hello
 V8_VERSION = master  # or e.g. branch-heads/6.3
 V8_ARCH = x64
 V8_MODE = release
-V8_DIR = v8
+V8_DIR ?= v8
 
 WASM_INTERPRETER = ../spec.master/interpreter/wasm   # change as needed
 


### PR DESCRIPTION
This commit enables the V8_DIR to be overriden when calling make, for
example:
```console
$ make V8_DIR=/path/to/v8
```
The motivation for this is that cloning and building v8 takes some a
while and this change allows using an existing clone of V8 instead.