### PR TITLE
Implement C++ API and reimplement C on top

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ ${EXAMPLE_OUT}: ${OUT_DIR}
 wasm: ${WASM_LIBS:%=%.o}
 
 ${WASM_O}: ${WASM_OUT}/%.o: ${WASM_SRC}/%.cc ${WASM_OUT}
-	clang++ -c -std=c++14 ${CXXFLAGS} -I. -I${V8_INCLUDE} -I${V8_SRC} -I${V8_V8} -I${V8_OUT}/gen -I${WASM_INCLUDE} -I${WASM_SRC} $< -o $@ -std=c++0x
+	clang++ -c -std=c++14 ${CXXFLAGS} -I. -I${V8_INCLUDE} -I${V8_SRC} -I${V8_V8} -I${V8_OUT}/gen -I${WASM_INCLUDE} -I${WASM_SRC} $< -o $@
 
 ${WASM_OUT}: ${OUT_DIR}
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS =
+CFLAGS = -ggdb
 CXXFLAGS = ${CFLAGS}
 
 OUT_DIR = out
@@ -79,11 +79,7 @@ ${EXAMPLE_OUT}: ${OUT_DIR}
 wasm: ${WASM_LIBS:%=%.o}
 
 ${WASM_O}: ${WASM_OUT}/%.o: ${WASM_SRC}/%.cc ${WASM_OUT}
-<<<<<<< HEAD
-	clang++ ${CXXFLAGS} -c -I. -I${V8_INCLUDE} -I${V8_SRC} -I${V8_V8} -I${V8_OUT}/gen -I${WASM_INCLUDE} -I${WASM_SRC} $< -o $@ -std=c++0x
-=======
-	clang++ -std=c++14 -c -I. -I${V8_INCLUDE} -I${V8_SRC} -I${V8_V8} -I${V8_OUT}/gen -I${WASM_INCLUDE} -I${WASM_SRC} $< -o $@
->>>>>>> WIP
+	clang++ -c -std=c++14 ${CXXFLAGS} -I. -I${V8_INCLUDE} -I${V8_SRC} -I${V8_V8} -I${V8_OUT}/gen -I${WASM_INCLUDE} -I${WASM_SRC} $< -o $@ -std=c++0x
 
 ${WASM_OUT}: ${OUT_DIR}
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+CFLAGS =
+CXXFLAGS = ${CFLAGS}
+
 OUT_DIR = out
 WASM_DIR = .
 EXAMPLE_DIR = example
@@ -5,6 +8,15 @@ EXAMPLE_DIR = example
 EXAMPLE_NAME = hello
 EXAMPLE_OUT = ${OUT_DIR}/${EXAMPLE_DIR}
 EXAMPLE_WAT = hello
+EXAMPLE_LANG = cc
+
+ifeq (${EXAMPLE_LANG},c)
+  EXAMPLE_CLANG = clang ${CFLAGS}
+endif
+ifeq (${EXAMPLE_LANG},cc)
+  EXAMPLE_CLANG = clang++ -std=c++14 ${CXXFLAGS}
+endif
+
 
 V8_VERSION = master  # or e.g. branch-heads/6.3
 V8_ARCH = x64
@@ -16,7 +28,7 @@ WASM_INTERPRETER = ../spec.master/interpreter/wasm   # change as needed
 WASM_INCLUDE = ${WASM_DIR}/include
 WASM_SRC = ${WASM_DIR}/src
 WASM_OUT = ${OUT_DIR}/${WASM_SRC}
-WASM_LIBS = wasm-v8 wasm-bin wasm-v8-lowlevel
+WASM_LIBS = wasm-v8 wasm-bin
 WASM_O = ${WASM_LIBS:%=${WASM_OUT}/%.o}
 
 V8_BUILD = ${V8_ARCH}.${V8_MODE}
@@ -31,17 +43,14 @@ V8_ICU_LIBS = uc i18n
 V8_OTHER_LIBS = src/inspector/libinspector
 V8_BIN = natives_blob snapshot_blob snapshot_blob_trusted
 
-CFLAGS =
-CXXFLAGS = ${CFLAGS}
-
 # Example
 
 .PHONY: example
 example: ${EXAMPLE_OUT}/${EXAMPLE_NAME} ${V8_BIN:%=${EXAMPLE_OUT}/%.bin} ${EXAMPLE_WAT:%=${EXAMPLE_OUT}/%.wasm}
 	cd ${EXAMPLE_OUT}; ./${EXAMPLE_NAME}
 
-${EXAMPLE_OUT}/${EXAMPLE_NAME}.o: ${EXAMPLE_DIR}/${EXAMPLE_NAME}.c ${WASM_INCLUDE}/wasm.h ${EXAMPLE_OUT}
-	clang ${CFLAGS} -c -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} $< -o $@
+${EXAMPLE_OUT}/${EXAMPLE_NAME}.o: ${EXAMPLE_DIR}/${EXAMPLE_NAME}.${EXAMPLE_LANG} ${WASM_INCLUDE}/wasm.h ${EXAMPLE_OUT}
+	${EXAMPLE_CLANG} -c -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} $< -o $@
 
 ${EXAMPLE_OUT}/${EXAMPLE_NAME}: ${EXAMPLE_OUT}/${EXAMPLE_NAME}.o ${WASM_O}
 	clang++ ${CXXFLAGS} $< -o $@ \
@@ -70,7 +79,11 @@ ${EXAMPLE_OUT}: ${OUT_DIR}
 wasm: ${WASM_LIBS:%=%.o}
 
 ${WASM_O}: ${WASM_OUT}/%.o: ${WASM_SRC}/%.cc ${WASM_OUT}
+<<<<<<< HEAD
 	clang++ ${CXXFLAGS} -c -I. -I${V8_INCLUDE} -I${V8_SRC} -I${V8_V8} -I${V8_OUT}/gen -I${WASM_INCLUDE} -I${WASM_SRC} $< -o $@ -std=c++0x
+=======
+	clang++ -std=c++14 -c -I. -I${V8_INCLUDE} -I${V8_SRC} -I${V8_V8} -I${V8_OUT}/gen -I${WASM_INCLUDE} -I${WASM_SRC} $< -o $@
+>>>>>>> WIP
 
 ${WASM_OUT}: ${OUT_DIR}
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,17 @@ V8_BIN = natives_blob snapshot_blob snapshot_blob_trusted
 
 # Example
 
-.PHONY: examples
-examples: ${EXAMPLE_OUT}/${EXAMPLE_NAME}-cc ${V8_BIN:%=${EXAMPLE_OUT}/%.bin} ${EXAMPLE_WAT:%=${EXAMPLE_OUT}/%.wasm}
+.PHONY: examples c cc
+examples: c cc
+	echo ==== Done ====
+
+c: ${EXAMPLE_OUT}/${EXAMPLE_NAME}-c ${V8_BIN:%=${EXAMPLE_OUT}/%.bin} ${EXAMPLE_WAT:%=${EXAMPLE_OUT}/%.wasm}
+	cd ${EXAMPLE_OUT} \
+	echo ==== C ====; \
+	./${EXAMPLE_NAME}-c \
+	echo ==== Done ====
+
+cc: ${EXAMPLE_OUT}/${EXAMPLE_NAME}-cc ${V8_BIN:%=${EXAMPLE_OUT}/%.bin} ${EXAMPLE_WAT:%=${EXAMPLE_OUT}/%.wasm}
 	cd ${EXAMPLE_OUT} \
 	echo ==== C++ ====; \
 	./${EXAMPLE_NAME}-cc \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CFLAGS = -ggdb
-CXXFLAGS = ${CFLAGS}
+CXXFLAGS = ${CFLAGS} -fsanitize=address
+LDFLAGS = -fsanitize-memory-track-origins -fsanitize-memory-use-after-dtor
 
 OUT_DIR = out
 WASM_DIR = .
@@ -18,8 +19,8 @@ WASM_INTERPRETER = ../spec.master/interpreter/wasm   # change as needed
 
 WASM_INCLUDE = ${WASM_DIR}/include
 WASM_SRC = ${WASM_DIR}/src
-WASM_OUT = ${OUT_DIR}/${WASM_SRC}
-WASM_LIBS = wasm-v8 wasm-bin
+WASM_OUT = ${OUT_DIR}/${WASM_DIR}
+WASM_LIBS = wasm-c wasm-v8 wasm-bin
 WASM_O = ${WASM_LIBS:%=${WASM_OUT}/%.o}
 
 V8_BUILD = ${V8_ARCH}.${V8_MODE}
@@ -38,28 +39,26 @@ V8_BIN = natives_blob snapshot_blob snapshot_blob_trusted
 
 .PHONY: examples c cc
 examples: c cc
-	echo ==== Done ====
+	@echo ==== Done ====
 
 c: ${EXAMPLE_OUT}/${EXAMPLE_NAME}-c ${V8_BIN:%=${EXAMPLE_OUT}/%.bin} ${EXAMPLE_WAT:%=${EXAMPLE_OUT}/%.wasm}
-	cd ${EXAMPLE_OUT} \
-	echo ==== C ====; \
-	./${EXAMPLE_NAME}-c \
-	echo ==== Done ====
+	@echo ==== C ====; \
+	cd ${EXAMPLE_OUT}; ./${EXAMPLE_NAME}-c
 
 cc: ${EXAMPLE_OUT}/${EXAMPLE_NAME}-cc ${V8_BIN:%=${EXAMPLE_OUT}/%.bin} ${EXAMPLE_WAT:%=${EXAMPLE_OUT}/%.wasm}
-	cd ${EXAMPLE_OUT} \
-	echo ==== C++ ====; \
-	./${EXAMPLE_NAME}-cc \
-	echo ==== Done ====
+	@echo ==== C++ ====; \
+	cd ${EXAMPLE_OUT}; ./${EXAMPLE_NAME}-cc
 
-${EXAMPLE_OUT}/${EXAMPLE_NAME}.c.o: ${EXAMPLE_DIR}/${EXAMPLE_NAME}.c ${WASM_INCLUDE}/wasm.h ${EXAMPLE_OUT}
+${EXAMPLE_OUT}/${EXAMPLE_NAME}.c.o: ${EXAMPLE_DIR}/${EXAMPLE_NAME}.c ${WASM_INCLUDE}/wasm.h
+	mkdir -p ${EXAMPLE_OUT}
 	clang -c ${CFLAGS} -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} $< -o $@
 
-${EXAMPLE_OUT}/${EXAMPLE_NAME}.cc.o: ${EXAMPLE_DIR}/${EXAMPLE_NAME}.cc ${WASM_INCLUDE}/wasm.hh ${EXAMPLE_OUT}
+${EXAMPLE_OUT}/${EXAMPLE_NAME}.cc.o: ${EXAMPLE_DIR}/${EXAMPLE_NAME}.cc ${WASM_INCLUDE}/wasm.hh
+	mkdir -p ${EXAMPLE_OUT}
 	clang++ -c -std=c++14 ${CXXFLAGS} -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} $< -o $@
 
 ${EXAMPLE_OUT}/${EXAMPLE_NAME}-%: ${EXAMPLE_OUT}/${EXAMPLE_NAME}.%.o ${WASM_O}
-	clang++ ${CXXFLAGS} $< -o $@ \
+	clang++ ${CXXFLAGS} ${LDFLAGS} $< -o $@ \
 		${V8_LIBS:%=${V8_OUT}/obj/libv8_%.a} \
 		${V8_ICU_LIBS:%=${V8_OUT}/obj/third_party/icu/libicu%.a} \
 		${V8_OTHER_LIBS:%=${V8_OUT}/obj/%.a} \
@@ -75,23 +74,15 @@ ${EXAMPLE_OUT}/%.wasm: ${EXAMPLE_DIR}/%.wasm
 %.wasm: %.wat
 	${WASM_INTERPRETER} -d $< -o $@
 
-${EXAMPLE_OUT}: ${OUT_DIR}
-	mkdir -p $@
-
 
 # Wasm C API
 
 .PHONY: wasm
-wasm: ${WASM_LIBS:%=%.o}
+wasm: ${WASM_LIBS:%=${WASM_OUT}/%.o}
 
-${WASM_O}: ${WASM_OUT}/%.o: ${WASM_SRC}/%.cc ${WASM_OUT}
+${WASM_O}: ${WASM_OUT}/%.o: ${WASM_SRC}/%.cc
+	mkdir -p ${WASM_OUT}
 	clang++ -c -std=c++14 ${CXXFLAGS} -I. -I${V8_INCLUDE} -I${V8_SRC} -I${V8_V8} -I${V8_OUT}/gen -I${WASM_INCLUDE} -I${WASM_SRC} $< -o $@
-
-${WASM_OUT}: ${OUT_DIR}
-	mkdir -p $@
-
-${OUT_DIR}:
-	mkdir -p $@
 
 
 # V8

--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
-# WebAssembly C API 
+# WebAssembly C and C++ API 
 
 Work in progress. No docs yet.
 
-* See `example/hello.c` for example usage.
+* C API:
 
-* See `include/wasm.h` for interface.
+  * See `example/hello.c` for example usage.
+
+  * See `include/wasm.h` for interface.
+
+* C++ API:
+
+  * See `example/hello.cc` for example usage.
+
+  * See `include/wasm.hh` for interface.
 
 * A half-complete implementation based on V8 is in `src`.
+
+* C API is build on top of C++ API.
 
 * See `Makefile` for build recipe.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,32 @@ Work in progress. No docs yet.
 * C API is build on top of C++ API.
 
 * See `Makefile` for build recipe.
+
+* TODO:
+
+  * Replace use of JS API with V8 internal
+
+  * Implement missing functionality through V8 internals
+
+    * global::get, global::set
+    * table::get, table::set, table::size, table::grow
+    * memory::data, memory::data_size, memory::size, memory::grow
+    * module::serialize, module::deserialize
+    * multiple return values
+
+  * Simplify reference wrappers to be plain persistent handles
+
+    * Move host information to V8 object (func callback & env)
+    * Compute reflection on demand
+
+  * Enforce const correctness
+
+  * Find a way to make C callbacks without extra wrapper?
+
+  * Possible renamings?
+
+    * `externkind`, `externtype` to `externalkind`, `externaltype`?
+    * `memtype` to `memorytype`?
+    * CamlCase class names in C++ API?
+
+  * Add iterators to `vec` class?

--- a/example/hello.c
+++ b/example/hello.c
@@ -50,8 +50,8 @@ own wasm_val_vec_t print_wasm(wasm_val_vec_t args) {
 int main(int argc, const char* argv[]) {
   // Initialize.
   printf("Initializing...\n");
-  wasm_init(argc, argv);
-  wasm_store_t* store = wasm_store_new();
+  wasm_engine_t* engine = wasm_engine_new(argc, argv);
+  wasm_store_t* store = wasm_store_new(engine);
 
   // Load binary.
   printf("Loading binary...\n");
@@ -126,7 +126,7 @@ int main(int argc, const char* argv[]) {
   // Shut down.
   printf("Shutting down...\n");
   wasm_store_delete(store);
-  wasm_deinit();
+  wasm_engine_delete(engine);
 
   // All done.
   printf("Done.\n");

--- a/example/hello.c
+++ b/example/hello.c
@@ -103,7 +103,7 @@ int main(int argc, const char* argv[]) {
   printf("Extracting exports...\n");
   own wasm_extern_t exp = wasm_instance_export(instance, 0);
   if (exp.kind != WASM_EXTERN_FUNC || exp.func == NULL) {
-    printf("> Error accessing export!");
+    printf("> Error accessing export!\n");
     return 1;
   }
   own wasm_func_t* run_func = exp.func;
@@ -113,7 +113,7 @@ int main(int argc, const char* argv[]) {
 
   // Call.
   printf("Calling exports...\n");
-  wasm_val_t args[] = {wasm_i32_val(3), wasm_i32_val(4)};
+  wasm_val_t args[] = { wasm_i32_val(3), wasm_i32_val(4) };
   own wasm_val_vec_t results = wasm_func_call(run_func, wasm_val_vec(2, args));
 
   // Print result.

--- a/example/hello.cc
+++ b/example/hello.cc
@@ -1,0 +1,127 @@
+#include <iostream>
+#include <fstream>
+#include <cstdlib>
+#include <string>
+#include <cinttypes>
+
+#include "wasm.hh"
+
+// Print a Wasm value
+void val_print(const wasm::val& val) {
+  switch (val.kind()) {
+    case wasm::I32: {
+      std::cout << val.i32();
+    } break;
+    case wasm::I64: {
+      std::cout << val.i64();
+    } break;
+    case wasm::F32: {
+      std::cout << val.f32();
+    } break;
+    case wasm::F64: {
+      std::cout << val.f64();
+    } break;
+    case wasm::ANYREF:
+    case wasm::FUNCREF: {
+      if (val.ref() == nullptr) {
+        std::cout << "null";
+      } else {
+        std::cout << "ref(" << val.ref() << ")";
+      }
+    } break;
+  }
+}
+
+// A function to be called from Wasm code.
+auto print_wasm(const wasm::vec<wasm::val>& args) -> wasm::vec<wasm::val> {
+  std::cout << "Calling back..." << std::endl << ">";
+  for (size_t i = 0; i < args.size(); ++i) {
+    std::cout << " ";
+    val_print(args[i]);
+  }
+  std::cout << std::endl;
+
+  int32_t n = args.size();
+  return wasm::vec<wasm::val>::make(wasm::val(n));
+}
+
+
+void run(int argc, const char* argv[]) {
+  // Initialize.
+  std::cout << "Initializing..." << std::endl;
+  auto engine = wasm::engine::make(argc, argv);
+  auto store = wasm::store::make(engine);
+
+  // Load binary.
+  std::cout << "Loading binary..." << std::endl;
+  std::ifstream file("hello.wasm");
+  file.seekg(0, std::ios_base::end);
+  auto file_size = file.tellg();
+  file.seekg(0);
+  auto binary = wasm::vec<byte_t>::make_uninitialized(file_size);
+  file.read(binary.get(), file_size);
+  file.close();
+  if (file.fail()) {
+    std::cout << "> Error loading module!" << std::endl;
+    return;
+  }
+
+  // Compile.
+  std::cout << "Compiling module..." << std::endl;
+  auto module = wasm::module::make(store, binary);
+  if (!module) {
+    std::cout << "> Error compiling module!" << std::endl;
+    return;
+  }
+
+  // Create external print functions.
+  std::cout << "Creating callbacks..." << std::endl;
+  auto print_type1 = wasm::functype::make(
+    wasm::vec<wasm::valtype*>::make(wasm::valtype::make(wasm::I32)),
+    wasm::vec<wasm::valtype*>::make(wasm::valtype::make(wasm::I32))
+  );
+  auto print_func1 = wasm::func::make(store, print_type1, print_wasm);
+
+  auto print_type2 = wasm::functype::make(
+    wasm::vec<wasm::valtype*>::make(wasm::valtype::make(wasm::I32), wasm::valtype::make(wasm::I32)),
+    wasm::vec<wasm::valtype*>::make(wasm::valtype::make(wasm::I32))
+  );
+  auto print_func2 = wasm::func::make(store, print_type2, print_wasm);
+
+  // Instantiate.
+  std::cout << "Instantiating module..." << std::endl;
+  auto imports = wasm::vec<wasm::external*>::make(print_func1, print_func2);
+  auto instance = wasm::instance::make(store, module, imports);
+  if (!instance) {
+    std::cout << "> Error instantiating module!" << std::endl;
+    return;
+  }
+
+  // Extract export.
+  std::cout << "Extracting exports..." << std::endl;
+  auto exports = instance->exports();
+  if (exports.size() == 0 || exports[0]->kind() != wasm::EXTERN_FUNC || !exports[0]->func()) {
+    std::cout << "> Error accessing export!" << std::endl;
+    return;
+  }
+  auto run_func = exports[0]->func();
+
+  // Call.
+  std::cout << "Calling exports..." << std::endl;
+  auto results = run_func->call(wasm::val(3), wasm::val(4));
+
+  // Print result.
+  std::cout << "Printing result..." << std::endl;
+  std::cout << "> " << results[0].i32() << std::endl;
+
+  // Shut down.
+  std::cout << "Shutting down..." << std::endl;
+}
+
+
+int main(int argc, const char* argv[]) {
+  run(argc, argv);
+  std::cout << "Done." << std::endl;
+  return 0;
+}
+

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -51,6 +51,12 @@ typedef double float64_t;
 // it merely indicates that this owner no longer uses it.
 
 
+#define WASM_DECLARE_OWN(name) \
+  typedef struct wasm_##name##_t wasm_##name##_t; \
+  \
+  void wasm_##name##_delete(own wasm_##name##_t*);
+
+
 // Vectors
 
 #define WASM_DECLARE_VEC(name, ptr_or_none) \
@@ -64,12 +70,9 @@ typedef double float64_t;
     return v; \
   } \
   \
-  static inline wasm_##name##_vec_t wasm_##name##_vec_empty() { \
-    return wasm_##name##_vec(0, NULL); \
-  } \
-  \
-  own wasm_##name##_vec_t wasm_##name##_vec_new(size_t, own wasm_##name##_t ptr_or_none const[]); \
+  own wasm_##name##_vec_t wasm_##name##_vec_new_empty(); \
   own wasm_##name##_vec_t wasm_##name##_vec_new_uninitialized(size_t); \
+  own wasm_##name##_vec_t wasm_##name##_vec_new(size_t, own wasm_##name##_t ptr_or_none const[]); \
   own wasm_##name##_vec_t wasm_##name##_vec_clone(wasm_##name##_vec_t); \
   void wasm_##name##_vec_delete(own wasm_##name##_vec_t);
 
@@ -83,6 +86,8 @@ typedef wasm_byte_vec_t wasm_name_t;
 
 #define wasm_name wasm_byte_vec
 #define wasm_name_new wasm_byte_vec_new
+#define wasm_name_new_empty wasm_byte_vec_new_empty
+#define wasm_name_new_new_uninitialized wasm_byte_vec_new_uninitialized
 #define wasm_name_clone wasm_byte_vec_clone
 #define wasm_name_delete wasm_byte_vec_delete
 
@@ -96,95 +101,84 @@ static inline own wasm_name_t wasm_name_new_from_string(const char* s) {
 
 // Configuration
 
-typedef struct wasm_config_t wasm_config_t;
+WASM_DECLARE_OWN(config)
 
 own wasm_config_t* wasm_config_new();
-void wasm_config_delete(own wasm_config_t*);
 
 // Embedders may provide custom functions for manipulating configs.
 
 
 // Engine
 
-typedef struct wasm_engine_t wasm_engine_t;
+WASM_DECLARE_OWN(engine)
 
-void wasm_engine_new(int argc, const char* const argv[]);
-void wasm_engine_new_with_config(int argc, const char* const argv[], own wasm_config_t*);
-void wasm_engine_delete();
+own wasm_engine_t* wasm_engine_new(int argc, const char* const argv[]);
+own wasm_engine_t* wasm_engine_new_with_config(int argc, const char* const argv[], own wasm_config_t*);
 
 
 // Store
 
-typedef struct wasm_store_t wasm_store_t;
+WASM_DECLARE_OWN(store)
 
 own wasm_store_t* wasm_store_new(wasm_engine_t*);
-void wasm_store_delete(own wasm_store_t*);
 
 
 ///////////////////////////////////////////////////////////////////////////////
 // Type Representations
-
-// Generic
-
-#define WASM_DECLARE_TYPE(name) \
-  typedef struct wasm_##name##_t wasm_##name##_t; \
-  \
-  void wasm_##name##_delete(own wasm_##name##_t*); \
-  own wasm_##name##_t* wasm_##name##_clone(wasm_##name##_t*); \
-  \
-  WASM_DECLARE_VEC(name, *)
-
-
-// Value Types
-
-WASM_DECLARE_TYPE(valtype)
-
-typedef wasm_valtype_t wasm_numtype_t;
-typedef wasm_valtype_t wasm_reftype_t;
-
-typedef enum wasm_valkind_t {
-  WASM_I32_VAL, WASM_I64_VAL, WASM_F32_VAL, WASM_F64_VAL,
-  WASM_ANYREF_VAL, WASM_FUNCREF_VAL
-} wasm_valkind_t;
-
-typedef wasm_valkind_t wasm_numkind_t;
-typedef wasm_valkind_t wasm_refkind_t;
-
-own wasm_valtype_t* wasm_valtype_new(wasm_valkind_t);
-
-wasm_valkind_t wasm_valtype_kind(wasm_valtype_t*);
-
-static inline bool wasm_valkind_is_numkind(wasm_valkind_t k) {
-  return k < WASM_ANYREF_VAL;
-}
-static inline bool wasm_valkind_is_refkind(wasm_valkind_t k) {
-  return k >= WASM_ANYREF_VAL;
-}
-
-static inline bool wasm_valtype_is_numtype(wasm_valtype_t* t) {
-  return wasm_valkind_is_numkind(wasm_valtype_kind(t));
-}
-static inline bool wasm_valtype_is_reftype(wasm_valtype_t* t) {
-  return wasm_valkind_is_refkind(wasm_valtype_kind(t));
-}
-
 
 // Tyoe atributes
 
 typedef enum wasm_mut_t { WASM_CONST, WASM_VAR } wasm_mut_t;
 
 typedef struct wasm_limits_t {
-  size_t min;
-  size_t max;
+  uint32_t min;
+  uint32_t max;
 } wasm_limits_t;
 
-static inline wasm_limits_t wasm_limits(size_t min, size_t max) {
+static inline wasm_limits_t wasm_limits(uint32_t min, uint32_t max) {
   wasm_limits_t l = {min, max};
   return l;
 }
 
-static inline wasm_limits_t wasm_limits_no_max(size_t min) {
-  return wasm_limits(min, SIZE_MAX);
+static inline wasm_limits_t wasm_limits_no_max(uint32_t min) {
+  return wasm_limits(min, 0xffffffff);
+}
+
+
+// Generic
+
+#define WASM_DECLARE_TYPE(name) \
+  WASM_DECLARE_OWN(name) \
+  WASM_DECLARE_VEC(name, *) \
+  \
+  own wasm_##name##_t* wasm_##name##_clone(wasm_##name##_t*);
+
+
+// Value Types
+
+WASM_DECLARE_TYPE(valtype)
+
+typedef enum wasm_valkind_t {
+  WASM_I32_VAL, WASM_I64_VAL, WASM_F32_VAL, WASM_F64_VAL,
+  WASM_ANYREF_VAL, WASM_FUNCREF_VAL
+} wasm_valkind_t;
+
+own wasm_valtype_t* wasm_valtype_new(wasm_valkind_t);
+
+wasm_valkind_t wasm_valtype_kind(wasm_valtype_t*);
+
+static inline bool wasm_valkind_is_num(wasm_valkind_t k) {
+  return k < WASM_ANYREF_VAL;
+}
+static inline bool wasm_valkind_is_ref(wasm_valkind_t k) {
+  return k >= WASM_ANYREF_VAL;
+}
+
+static inline bool wasm_valtype_is_num(wasm_valtype_t* t) {
+  return wasm_valkind_is_num(wasm_valtype_kind(t));
+}
+static inline bool wasm_valtype_is_ref(wasm_valtype_t* t) {
+  return wasm_valkind_is_ref(wasm_valtype_kind(t));
 }
 
 
@@ -212,9 +206,9 @@ wasm_mut_t wasm_globaltype_mut(wasm_globaltype_t*);
 
 WASM_DECLARE_TYPE(tabletype)
 
-own wasm_tabletype_t* wasm_tabletype_new(own wasm_reftype_t*, wasm_limits_t);
+own wasm_tabletype_t* wasm_tabletype_new(own wasm_valtype_t*, wasm_limits_t);
 
-wasm_reftype_t* wasm_tabletype_elem(wasm_tabletype_t*);
+wasm_valtype_t* wasm_tabletype_element(wasm_tabletype_t*);
 wasm_limits_t wasm_tabletype_limits(wasm_tabletype_t*);
 
 
@@ -271,33 +265,9 @@ wasm_externtype_t* wasm_exporttype_type(wasm_exporttype_t*);
 ///////////////////////////////////////////////////////////////////////////////
 // Runtime Objects
 
-// References
-
-typedef struct wasm_ref_t wasm_ref_t;
-
-void wasm_ref_delete(own wasm_ref_t*);
-own wasm_ref_t* wasm_ref_clone(wasm_ref_t*);
-
-own wasm_ref_t* wasm_ref_null();
-
-bool wasm_ref_is_null(wasm_ref_t*);
-
-
-#define WASM_DECLARE_REF(name) \
-  typedef struct wasm_##name##_t wasm_##name##_t; \
-  \
-  void wasm_##name##_delete(own wasm_##name##_t*); \
-  own wasm_##name##_t* wasm_##name##_clone(wasm_##name##_t*); \
-  \
-  wasm_ref_t* wasm_##name##_as_ref(wasm_##name##_t*); \
-  wasm_##name##_t* wasm_ref_as_##name(wasm_ref_t*); \
-  \
-  void* wasm_##name##_get_host_info(wasm_##name##_t*); \
-  void wasm_##name##_set_host_info(wasm_##name##_t*, void*); \
-  void wasm_##name##_set_host_info_with_finalizer(wasm_##name##_t*, void*, void (*)(void*));
-
-
 // Values
+
+struct wasm_ref_t;
 
 typedef struct wasm_val_t {
   wasm_valkind_t kind;
@@ -306,7 +276,7 @@ typedef struct wasm_val_t {
     uint64_t i64;
     float32_t f32;
     float64_t f64;
-    wasm_ref_t* ref;
+    struct wasm_ref_t* ref;
   };
 } wasm_val_t;
 
@@ -314,6 +284,26 @@ void wasm_val_delete(own wasm_val_t v);
 own wasm_val_t wasm_val_clone(wasm_val_t);
 
 WASM_DECLARE_VEC(val, )
+
+
+// References
+
+WASM_DECLARE_OWN(ref)
+
+own wasm_ref_t* wasm_ref_clone(wasm_ref_t*);
+
+
+#define WASM_DECLARE_REF(name) \
+  WASM_DECLARE_OWN(name) \
+  \
+  own wasm_##name##_t* wasm_##name##_clone(wasm_##name##_t*); \
+  \
+  wasm_ref_t* wasm_##name##_as_ref(wasm_##name##_t*); \
+  wasm_##name##_t* wasm_ref_as_##name(wasm_ref_t*); \
+  \
+  void* wasm_##name##_get_host_info(wasm_##name##_t*); \
+  void wasm_##name##_set_host_info(wasm_##name##_t*, void*); \
+  void wasm_##name##_set_host_info_with_finalizer(wasm_##name##_t*, void*, void (*)(void*));
 
 
 // Modules
@@ -458,27 +448,27 @@ static inline own wasm_valtype_t* wasm_valtype_new_funcref() {
 // Function Types construction short-hands
 
 static inline own wasm_functype_t* wasm_functype_new_0_0() {
-  return wasm_functype_new(wasm_valtype_vec_empty(), wasm_valtype_vec_empty());
+  return wasm_functype_new(wasm_valtype_vec_new_empty(), wasm_valtype_vec_new_empty());
 }
 
 static inline own wasm_functype_t* wasm_functype_new_1_0(own wasm_valtype_t* p) {
   wasm_valtype_t* ps[1] = {p};
-  return wasm_functype_new(wasm_valtype_vec_new(1, ps), wasm_valtype_vec_empty());
+  return wasm_functype_new(wasm_valtype_vec_new(1, ps), wasm_valtype_vec_new_empty());
 }
 
 static inline own wasm_functype_t* wasm_functype_new_2_0(own wasm_valtype_t* p1, own wasm_valtype_t* p2) {
   wasm_valtype_t* ps[2] = {p1, p2};
-  return wasm_functype_new(wasm_valtype_vec_new(2, ps), wasm_valtype_vec_empty());
+  return wasm_functype_new(wasm_valtype_vec_new(2, ps), wasm_valtype_vec_new_empty());
 }
 
 static inline own wasm_functype_t* wasm_functype_new_3_0(own wasm_valtype_t* p1, own wasm_valtype_t* p2, own wasm_valtype_t* p3) {
   wasm_valtype_t* ps[3] = {p1, p2, p3};
-  return wasm_functype_new(wasm_valtype_vec_new(3, ps), wasm_valtype_vec_empty());
+  return wasm_functype_new(wasm_valtype_vec_new(3, ps), wasm_valtype_vec_new_empty());
 }
 
 static inline own wasm_functype_t* wasm_functype_new_0_1(own wasm_valtype_t* r) {
   wasm_valtype_t* rs[1] = {r};
-  return wasm_functype_new(wasm_valtype_vec_empty(), wasm_valtype_vec_new(1, rs));
+  return wasm_functype_new(wasm_valtype_vec_new_empty(), wasm_valtype_vec_new(1, rs));
 }
 
 static inline own wasm_functype_t* wasm_functype_new_1_1(own wasm_valtype_t* p, own wasm_valtype_t* r) {
@@ -501,7 +491,7 @@ static inline own wasm_functype_t* wasm_functype_new_3_1(own wasm_valtype_t* p1,
 
 static inline own wasm_functype_t* wasm_functype_new_0_2(own wasm_valtype_t* r1, own wasm_valtype_t* r2) {
   wasm_valtype_t* rs[2] = {r1, r2};
-  return wasm_functype_new(wasm_valtype_vec_empty(), wasm_valtype_vec_new(2, rs));
+  return wasm_functype_new(wasm_valtype_vec_new_empty(), wasm_valtype_vec_new(2, rs));
 }
 
 static inline own wasm_functype_t* wasm_functype_new_1_2(own wasm_valtype_t* p, own wasm_valtype_t* r1, own wasm_valtype_t* r2) {
@@ -556,7 +546,7 @@ static inline own wasm_val_t wasm_ref_val(wasm_ref_t* ref) {
 }
 
 static inline own wasm_val_t wasm_null_val() {
-  return wasm_ref_val(wasm_ref_null());
+  return wasm_ref_val(NULL);
 }
 
 static inline own wasm_val_t wasm_ptr_val(void* p) {

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -92,6 +92,36 @@ static inline own wasm_name_t wasm_name_new_from_string(const char* s) {
 
 
 ///////////////////////////////////////////////////////////////////////////////
+// Runtime Environment
+
+// Configuration
+
+typedef struct wasm_config_t wasm_config_t;
+
+own wasm_config_t* wasm_config_new();
+void wasm_config_delete(own wasm_config_t*);
+
+// Embedders may provide custom functions for manipulating configs.
+
+
+// Engine
+
+typedef struct wasm_engine_t wasm_engine_t;
+
+void wasm_engine_new(int argc, const char* const argv[]);
+void wasm_engine_new_with_config(int argc, const char* const argv[], own wasm_config_t*);
+void wasm_engine_delete();
+
+
+// Store
+
+typedef struct wasm_store_t wasm_store_t;
+
+own wasm_store_t* wasm_store_new(wasm_engine_t*);
+void wasm_store_delete(own wasm_store_t*);
+
+
+///////////////////////////////////////////////////////////////////////////////
 // Type Representations
 
 // Generic
@@ -236,36 +266,6 @@ own wasm_exporttype_t* wasm_exporttype_new(own wasm_name_t, own wasm_externtype_
 
 wasm_name_t wasm_exporttype_name(wasm_exporttype_t*);
 wasm_externtype_t* wasm_exporttype_type(wasm_exporttype_t*);
-
-
-///////////////////////////////////////////////////////////////////////////////
-// Runtime Environment
-
-// Configuration
-
-typedef struct wasm_config_t wasm_config_t;
-
-own wasm_config_t* wasm_config_new();
-void wasm_config_delete(own wasm_config_t*);
-
-// Embedders may provide custom functions for manipulating configs.
-
-
-// Engine
-
-typedef struct wasm_engine_t wasm_engine_t;
-
-void wasm_engine_new(int argc, const char* const argv[]);
-void wasm_engine_new_with_config(int argc, const char* const argv[], own wasm_config_t*);
-void wasm_engine_delete();
-
-
-// Store
-
-typedef struct wasm_store_t wasm_store_t;
-
-own wasm_store_t* wasm_store_new(wasm_engine_t*);
-void wasm_store_delete(own wasm_store_t*);
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -241,7 +241,7 @@ wasm_externtype_t* wasm_exporttype_type(wasm_exporttype_t*);
 ///////////////////////////////////////////////////////////////////////////////
 // Runtime Environment
 
-// Initialisation
+// Configuration
 
 typedef struct wasm_config_t wasm_config_t;
 
@@ -250,16 +250,21 @@ void wasm_config_delete(own wasm_config_t*);
 
 // Embedders may provide custom functions for manipulating configs.
 
-void wasm_init(int argc, const char* const argv[]);
-void wasm_init_with_config(int argc, const char* const argv[], own wasm_config_t*);
-void wasm_deinit();
+
+// Engine
+
+typedef struct wasm_engine_t wasm_engine_t;
+
+void wasm_engine_new(int argc, const char* const argv[]);
+void wasm_engine_new_with_config(int argc, const char* const argv[], own wasm_config_t*);
+void wasm_engine_delete();
 
 
 // Store
 
 typedef struct wasm_store_t wasm_store_t;
 
-own wasm_store_t* wasm_store_new();
+own wasm_store_t* wasm_store_new(wasm_engine_t*);
 void wasm_store_delete(own wasm_store_t*);
 
 

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -70,6 +70,10 @@ typedef double float64_t;
     return v; \
   } \
   \
+  wasm_##name##_vec_t wasm_##name##_vec_empty() { \
+    return wasm_##name##_vec(0, NULL); \
+  } \
+  \
   own wasm_##name##_vec_t wasm_##name##_vec_new_empty(); \
   own wasm_##name##_vec_t wasm_##name##_vec_new_uninitialized(size_t); \
   own wasm_##name##_vec_t wasm_##name##_vec_new(size_t, own wasm_##name##_t ptr_or_none const[]); \

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -14,10 +14,10 @@
 
 // Machine types
 
-static_assert(sizeof(float) == sizeof(uint32_t), "incompatible float type");
-static_assert(sizeof(double) == sizeof(uint64_t), "incompatible double type");
-static_assert(sizeof(intptr_t) == sizeof(uint32_t) ||
-              sizeof(intptr_t) == sizeof(uint64_t), "incompatible pointer type");
+static_assert(sizeof(float) == sizeof(int32_t), "incompatible float type");
+static_assert(sizeof(double) == sizeof(int64_t), "incompatible double type");
+static_assert(sizeof(intptr_t) == sizeof(int32_t) ||
+              sizeof(intptr_t) == sizeof(int64_t), "incompatible pointer type");
 
 using byte_t = char;
 using float32_t = float;

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -264,15 +264,41 @@ public:
 };
 
 
+// External Types
+
+enum externkind {
+  EXTERN_FUNC, EXTERN_GLOBAL, EXTERN_TABLE, EXTERN_MEMORY
+};
+
+class functype;
+class globaltype;
+class tabletype;
+class memtype;
+
+class externtype {
+public:
+  externtype() = delete;
+  ~externtype();
+  void operator delete(void*);
+
+  auto clone() const-> own<externtype*>;
+
+  auto kind() const -> externkind;
+  auto func() -> functype*;
+  auto global() -> globaltype*;
+  auto table() -> tabletype*;
+  auto memory() -> memtype*;
+};
+
+
 // Function Types
 
 enum class arrow { ARROW };
 
-class functype {
+class functype : public externtype {
 public:
   functype() = delete;
   ~functype();
-  void operator delete(void*);
 
   static auto make(
     vec<valtype*>&& params = vec<valtype*>::make(),
@@ -288,11 +314,10 @@ public:
 
 // Global Types
 
-class globaltype {
+class globaltype : public externtype {
 public:
   globaltype() = delete;
   ~globaltype();
-  void operator delete(void*);
 
   static auto make(own<valtype*>&&, mut) -> own<globaltype*>;
   auto clone() const -> own<globaltype*>;
@@ -304,11 +329,10 @@ public:
 
 // Table Types
 
-class tabletype {
+class tabletype : public externtype {
 public:
   tabletype() = delete;
   ~tabletype();
-  void operator delete(void*);
 
   static auto make(own<valtype*>&&, limits) -> own<tabletype*>;
   auto clone() const -> own<tabletype*>;
@@ -320,43 +344,15 @@ public:
 
 // Memory Types
 
-class memtype {
+class memtype : public externtype {
 public:
   memtype() = delete;
   ~memtype();
-  void operator delete(void*);
 
   static auto make(limits) -> own<memtype*>;
   auto clone() const -> own<memtype*>;
 
   auto limits() const -> limits;
-};
-
-
-// External Types
-
-enum externkind {
-  EXTERN_FUNC, EXTERN_GLOBAL, EXTERN_TABLE, EXTERN_MEMORY
-};
-
-class externtype {
-public:
-  externtype() = delete;
-  ~externtype();
-  void operator delete(void*);
-
-  static auto make(own<functype*>&&) -> own<externtype*>;
-  static auto make(own<globaltype*>&&) -> own<externtype*>;
-  static auto make(own<tabletype*>&&) -> own<externtype*>;
-  static auto make(own<memtype*>&&) -> own<externtype*>;
-
-  auto clone() const-> own<externtype*>;
-
-  auto kind() const -> externkind;
-  auto func() -> functype*;
-  auto global() -> globaltype*;
-  auto table() -> tabletype*;
-  auto memory() -> memtype*;
 };
 
 
@@ -452,7 +448,6 @@ class module : public ref {
 public:
   module() = delete;
   ~module();
-  void operator delete(void*);
 
   static auto validate(own<store*>&, size_t, const byte_t[]) -> bool;
   static auto make(own<store*>&, size_t, const byte_t[]) -> own<module*>;
@@ -479,7 +474,6 @@ class hostobj : public ref {
 public:
   hostobj() = delete;
   ~hostobj();
-  void operator delete(void*);
 
   static auto make(own<store*>&) -> own<hostobj*>;
   auto clone() const -> own<hostobj*>;
@@ -497,7 +491,6 @@ class external : public ref {
 public:
   external() = delete;
   ~external();
-  void operator delete(void*);
 
   auto clone() const -> own<external*>;
 
@@ -515,7 +508,6 @@ class func : public external {
 public:
   func() = delete;
   ~func();
-  void operator delete(void*);
 
   using callback = auto (*)(vec<val>&) -> vec<val>;
   using callback_with_env = auto (*)(void*, vec<val>&) -> vec<val>;
@@ -540,7 +532,6 @@ class global : public external {
 public:
   global() = delete;
   ~global();
-  void operator delete(void*);
 
   static auto make(own<store*>&, own<globaltype*>&, val) -> own<global*>;
   auto clone() const -> own<global*>;
@@ -557,7 +548,6 @@ class table : public external {
 public:
   table() = delete;
   ~table();
-  void operator delete(void*);
 
   using size_t = uint32_t;
 
@@ -578,7 +568,6 @@ class memory : public external {
 public:
   memory() = delete;
   ~memory();
-  void operator delete(void*);
 
   static auto make(own<store*>&, own<memtype*>&) -> own<memory*>;
   auto clone() const -> own<memory*>;
@@ -601,7 +590,6 @@ class instance : public ref {
 public:
   instance() = delete;
   ~instance();
-  void operator delete(void*);
 
   static auto make(own<store*>&, own<module*>&, vec<external*>&) -> own<instance*>;
   auto clone() const -> own<instance*>;

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -8,8 +8,6 @@
 #include <memory>
 #include <limits>
 
-#include <iostream>  // TODO
-
 
 ///////////////////////////////////////////////////////////////////////////////
 // Auxiliaries
@@ -145,20 +143,14 @@ struct own_vec {
   size_t size;
   own<T[]> data;
 
-  own_vec() : size(0) {
-    assert(!!size <= !!data);
-  }
+  own_vec() : size(0) {}
 
   template<class U>
   own_vec(own_vec<U>&& that) : size(that.size), data(that.data.release()) {
     that.size = 0;
-    assert(!!size <= !!data);
-    assert(!!that.size <= !!that.data);
   }
 
-  ~own_vec() {
-std::cout << "own_vec(" << size<<", "<<(void*)data.get()<<")"<<std::endl;
-   vec_traits<T>::destruct(size, data.get()); }
+  ~own_vec() { vec_traits<T>::destruct(size, data.get()); }
 
   template<class U>
   auto operator=(own_vec<U>&& that) -> own_vec& {
@@ -166,8 +158,6 @@ std::cout << "own_vec(" << size<<", "<<(void*)data.get()<<")"<<std::endl;
     size = that.size;
     data.reset(that.data.release());
     that.size = 0;
-    assert(!!size <= !!data);
-    assert(!!that.size <= !!that.data);
     return *this;
   }
 
@@ -178,7 +168,6 @@ std::cout << "own_vec(" << size<<", "<<(void*)data.get()<<")"<<std::endl;
   auto release() -> vec<T> {
     auto s = size;
     size = 0;
-assert(!!size <= !!data);
     return vec<T>(s, data.release());
   }
 
@@ -186,7 +175,6 @@ assert(!!size <= !!data);
     vec_traits<T>::destruct(size, data.get());
     size = 0;
     data.reset();
-    assert(!!size <= !!data);
   }
 
   operator bool() const {
@@ -218,10 +206,7 @@ assert(!!size <= !!data);
   }
 
 private:
-  own_vec(size_t size, T data[]) : size(size), data(data) {
-std::cout << "own_vec(" << size<<", "<<(void*)data<<")"<<std::endl;
-    assert(!!size <= !!data);
-  }
+  own_vec(size_t size, T data[]) : size(size), data(data) {}
 };
 
 
@@ -250,10 +235,8 @@ inline bool is_ref(valkind k) { return k >= ANYREF; }
 
 
 class valtype {
-protected:
-  valtype() {}
-
 public:
+  valtype() = delete;
   ~valtype();
 
   static auto make(valkind) -> own<valtype*>;
@@ -270,22 +253,14 @@ public:
 enum class arrow { ARROW };
 
 class functype {
-protected:
-  functype() {}
-
 public:
+  functype() = delete;
   ~functype();
 
-  static auto make(own<vec<valtype*>>&& params = vec<valtype*>::make(), own<vec<valtype*>>&& results = vec<valtype*>::make()) -> own<functype*>;
-
-/*
-  auto make() {
-    return make(vec<valtype*>(), vec<valtype*>());
-  }
-  auto make(std::initializer_list<own<valtype*>> params) {
-    return make(vec<valtype*>::make(params.size(),), vec<valtype*>());
-  }
-*/
+  static auto make(
+    own<vec<valtype*>>&& params = vec<valtype*>::make(),
+    own<vec<valtype*>>&& results = vec<valtype*>::make()
+  ) -> own<functype*>;
 
   auto clone() const -> own<functype*>;
 
@@ -297,10 +272,8 @@ public:
 // Global Types
 
 class globaltype {
-protected:
-  globaltype() {}
-
 public:
+  globaltype() = delete;
   ~globaltype();
 
   static auto make(own<valtype*>&&, mut) -> own<globaltype*>;
@@ -314,10 +287,8 @@ public:
 // Table Types
 
 class tabletype {
-protected:
-  tabletype() {}
-
 public:
+  tabletype() = delete;
   ~tabletype();
 
   static auto make(own<valtype*>&&, limits) -> own<tabletype*>;
@@ -331,10 +302,8 @@ public:
 // Memory Types
 
 class memtype {
-protected:
-  memtype() {}
-
 public:
+  memtype() = delete;
   ~memtype();
 
   static auto make(limits) -> own<memtype*>;
@@ -351,10 +320,8 @@ enum externkind {
 };
 
 class externtype {
-protected:
-  externtype() {}
-
 public:
+  externtype() = delete;
   ~externtype();
 
   static auto make(own<functype*>) -> own<externtype*>;
@@ -377,10 +344,8 @@ public:
 using name = vec<byte_t>;
 
 class importtype {
-protected:
-  importtype() {}
-
 public:
+  importtype() = delete;
   ~importtype();
 
   static auto make(own<name>&& module, own<name>&& name, own<externtype*>&&) -> own<importtype*>;
@@ -395,10 +360,8 @@ public:
 // Export Types
 
 class exporttype {
-protected:
-  exporttype() {}
-
 public:
+  exporttype() = delete;
   ~exporttype();
 
   static auto make(own<name>&& name, own<externtype*>&&) -> own<exporttype*>;
@@ -412,13 +375,11 @@ public:
 ///////////////////////////////////////////////////////////////////////////////
 // Runtime Environment
 
-// Initialisation
+// Configuration
 
 class config {
-protected:
-  config() {}
-
 public:
+  config() = delete;
   ~config();
 
   static auto make() -> own<config*>;
@@ -427,11 +388,11 @@ public:
 };
 
 
-class engine {
-protected:
-  engine() {}
+// Engine
 
+class engine {
 public:
+  engine() = delete;
   ~engine();
 
   static auto make(int argc, const char* const argv[], own<config*>&& = config::make()) -> own<engine*>;
@@ -441,13 +402,11 @@ public:
 // Store
 
 class store {
-protected:
-  store() {}
-
 public:
+  store() = delete;
   ~store();
 
-  static auto make(engine*) -> own<store*>;
+  static auto make(own<engine*>&) -> own<store*>;
 };
 
 
@@ -457,10 +416,8 @@ public:
 // References
 
 class ref {
-protected:
-  ref() {}
-
 public:
+  ref() = delete;
   ~ref();
 
   auto clone() const -> own<ref*>;
@@ -472,29 +429,7 @@ public:
 
 // Values
 
-struct val;
-struct own_val;
-template<> struct owner<val> { using type = own_val; };
-template<> struct owner<own_val> { using type = own_val; };
-
-struct val {
-  val() : kind_(ANYREF), ref_(nullptr) {}
-  val(int32_t i) : kind_(I32), i32_(i) {}
-  val(int64_t i) : kind_(I64), i64_(i) {}
-  val(float32_t z) : kind_(F32), f32_(z) {}
-  val(float64_t z) : kind_(F64), f64_(z) {}
-  val(wasm::ref* r) : kind_(ANYREF), ref_(r) {}
-
-  auto kind() const -> valkind { return kind_; }
-  auto i32() const -> int32_t { return kind_ == I32 ? i32_ : 0; }
-  auto i64() const -> int64_t { return kind_ == I64 ? i64_ : 0; }
-  auto f32() const -> float32_t { return kind_ == F32 ? f32_ : 0; }
-  auto f64() const -> float64_t { return kind_ == F64 ? f64_ : 0; }
-  auto ref() const -> wasm::ref* { return is_ref(kind_) ? ref_ : nullptr; }
-
-  auto clone() const -> own<val>;
-
-private:
+class val {
   valkind kind_;
   union {
     int32_t i32_;
@@ -503,29 +438,40 @@ private:
     float64_t f64_;
     wasm::ref* ref_;
   };
-};
 
-struct own_val : val {
-  own_val() {}
-  own_val(const val& v) : val(v) {}
-  ~own_val() { if (is_ref(kind()) && ref() != nullptr) delete ref(); }
+public:
+  val() : kind_(ANYREF), ref_(nullptr) {}
+  val(int32_t i) : kind_(I32), i32_(i) {}
+  val(int64_t i) : kind_(I64), i64_(i) {}
+  val(float32_t z) : kind_(F32), f32_(z) {}
+  val(float64_t z) : kind_(F64), f64_(z) {}
+  val(own<wasm::ref*>&& r) : kind_(ANYREF), ref_(r.release()) {}
+
+  ~val() { if (is_ref(kind_) && ref_) delete ref_; }
+
+  auto kind() const -> valkind { return kind_; }
+  auto i32() const -> int32_t { return kind_ == I32 ? i32_ : 0; }
+  auto i64() const -> int64_t { return kind_ == I64 ? i64_ : 0; }
+  auto f32() const -> float32_t { return kind_ == F32 ? f32_ : 0; }
+  auto f64() const -> float64_t { return kind_ == F64 ? f64_ : 0; }
+  auto ref() const -> wasm::ref* { return is_ref(kind_) ? ref_ : nullptr; }
+
+  auto clone() const -> val;
 };
 
 
 // Modules
 
 class module : public ref {
-protected:
-  module() {}
-
 public:
+  module() = delete;
   ~module();
 
   using binary = vec<byte_t>;
   using serialized = vec<byte_t>;
 
-  static auto validate(store*, binary) -> bool;
-  static auto make(store*, binary) -> own<module*>;
+  static auto validate(own<store*>&, binary) -> bool;
+  static auto make(own<store*>&, binary) -> own<module*>;
   auto clone() const -> own<module*>;
 
   auto imports() -> own<vec<importtype*>>;
@@ -539,13 +485,11 @@ public:
 // Host Objects
 
 class hostobj : public ref {
-protected:
-  hostobj() {}
-
 public:
+  hostobj() = delete;
   ~hostobj();
 
-  static auto make(store*) -> own<hostobj*>;
+  static auto make(own<store*>&) -> own<hostobj*>;
   auto clone() const -> own<hostobj*>;
 };
 
@@ -558,10 +502,8 @@ class table;
 class memory;
 
 class external : public ref {
-protected:
-  external() {}
-
 public:
+  external() = delete;
   ~external();
 
   auto clone() const -> own<external*>;
@@ -577,17 +519,15 @@ public:
 // Function Instances
 
 class func : public external {
-protected:
-  func() {}
-
 public:
+  func() = delete;
   ~func();
 
   using callback = auto (*)(vec<val>) -> own<vec<val>>;
   using callback_with_env = auto (*)(void*, vec<val>) -> own<vec<val>>;
 
-  static auto make(store*, functype*, callback) -> own<func*>;
-  static auto make(store*, functype*, callback_with_env, void*) -> own<func*>;
+  static auto make(own<store*>&, own<functype*>&, callback) -> own<func*>;
+  static auto make(own<store*>&, own<functype*>&, callback_with_env, void*) -> own<func*>;
   auto clone() const -> own<func*>;
 
   auto type() const -> own<functype*>;
@@ -598,17 +538,15 @@ public:
 // Global Instances
 
 class global : public external {
-protected:
-  global() {}
-
 public:
+  global() = delete;
   ~global();
 
-  static auto make(store*, globaltype*, val) -> own<global*>;
+  static auto make(own<store*>&, own<globaltype*>&, val) -> own<global*>;
   auto clone() const -> own<global*>;
 
   auto type() const -> own<globaltype*>;
-  auto get() const -> own<val>;
+  auto get() const -> val;
   void set(val);
 };
 
@@ -616,15 +554,13 @@ public:
 // Table Instances
 
 class table : public external {
-protected:
-  table() {}
-
 public:
+  table() = delete;
   ~table();
 
   using size_t = uint32_t;
 
-  static auto make(store*, tabletype*, ref*) -> own<table*>;
+  static auto make(own<store*>&, own<tabletype*>&, ref*) -> own<table*>;
   auto clone() const -> own<table*>;
 
   auto type() const -> own<tabletype*>;
@@ -638,13 +574,11 @@ public:
 // Memory Instances
 
 class memory : public external {
-protected:
-  memory() {}
-
 public:
+  memory() = delete;
   ~memory();
 
-  static auto make(store*, memtype*) -> own<memory*>;
+  static auto make(own<store*>&, own<memtype*>&) -> own<memory*>;
   auto clone() const -> own<memory*>;
 
   using pages_t = uint32_t;
@@ -662,59 +596,16 @@ public:
 // Module Instances
 
 class instance : public ref {
-protected:
-  instance() {}
-
 public:
+  instance() = delete;
   ~instance();
 
-  static auto make(store*, module*, vec<external*>) -> own<instance*>;
+  static auto make(own<store*>&, own<module*>&, vec<external*>) -> own<instance*>;
   auto clone() const -> own<instance*>;
 
   auto exports() const -> own<vec<external*>>;
 };
 
-
-///////////////////////////////////////////////////////////////////////////////
-// Convenience
-
-// Value Type construction short-hands
-
-inline own<valtype*> valtype_i32() { return valtype::make(I32); }
-inline own<valtype*> valtype_i64() { return valtype::make(I64); }
-inline own<valtype*> valtype_f32() { return valtype::make(F32); }
-inline own<valtype*> valtype_f64() { return valtype::make(F64); }
-inline own<valtype*> valtype_anyref() { return valtype::make(ANYREF); }
-inline own<valtype*> valtype_funcref() { return valtype::make(FUNCREF); }
-
-
-// Function Types construction short-hands
-
-/*
-
-// Value construction short-hands
-
-inline own wasm_val_t wasm_null_val() {
-  return wasm_ref_val(wasm_ref_null());
-}
-
-inline own wasm_val_t wasm_ptr_val(void* p) {
-#if UINTPTR_MAX == UINT32_MAX
-  return wasm_i32_val((uintptr_t)p);
-#elif UINTPTR_MAX == UINT64_MAX
-  return wasm_i64_val((uintptr_t)p);
-#endif
-}
-
-inline void* wasm_val_ptr(wasm_val_t v) {
-#if UINTPTR_MAX == UINT32_MAX
-  return (void*)(uintptr_t)v.i32;
-#elif UINTPTR_MAX == UINT64_MAX
-  return (void*)(uintptr_t)v.i64;
-#endif
-}
-
-*/
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -158,7 +158,6 @@ struct own_vec {
 
   ~own_vec() {
 std::cout << "own_vec(" << size<<", "<<(void*)data.get()<<")"<<std::endl;
-    if (!(!!size <= !!data)) data.get()[0];
    vec_traits<T>::destruct(size, data.get()); }
 
   template<class U>
@@ -427,8 +426,16 @@ public:
   // Embedders may provide custom methods for manipulating configs.
 };
 
-void init(int argc, const char* const argv[], own<config*>&& = config::make());
-void deinit();
+
+class engine {
+protected:
+  engine() {}
+
+public:
+  ~engine();
+
+  static auto make(int argc, const char* const argv[], own<config*>&& = config::make()) -> own<engine*>;
+};
 
 
 // Store
@@ -440,7 +447,7 @@ protected:
 public:
   ~store();
 
-  static auto make() -> own<store*>;
+  static auto make(engine*) -> own<store*>;
 };
 
 

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -1,0 +1,558 @@
+// WebAssembly C++ API
+
+#ifndef __WASM_HH
+#define __WASM_HH
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Auxiliaries
+
+// Machine types
+
+static_assert(sizeof(float) == sizeof(uint32_t), "incompatible float type");
+static_assert(sizeof(double) == sizeof(uint64_t), "incompatible double type");
+static_assert(sizeof(intptr_t) == sizeof(uint32_t) ||
+              sizeof(intptr_t) == sizeof(uint64_t), "incompatible pointer type");
+
+using byte_t = char;
+using float32_t = float;
+using float64_t = double;
+
+
+namespace wasm {
+
+// Ownership
+
+template<class T> struct ownership;
+template<class T> struct ownership<byte_t> { using type = byte_t; };
+template<class T> struct ownership<T*> { using type = std::unique_ptr<T>; };
+template<class T> struct ownership<T[]> {
+  using type = std::unique_ptr<typename ownership<T>::type[]>;
+};
+
+template<class T> using own = typename ownership<T>::type;
+
+
+// Vectors
+
+template<class T> struct own_vec;
+template<class T> struct ownership<vec<T>> { using type = own_vec<T>; };
+
+template<class T>
+struct vec {
+  const size_t size = 0;
+  T* const data = nullptr;
+
+  auto operator[](size_t i) const -> T& {
+    return data[i];
+  }
+
+  auto clone() const -> own<vec<T>> {
+    return make(size, data);
+  }
+
+  static auto make(size_t size) -> own<vec<T>> {
+    return own<vec<T>>(vec(size, size == 0 ? nullptr : new T[size]));
+  }
+
+  static auto make(size_t size, const T data[]) -> own<vec<T>> {
+    auto v = make(size);
+    for (size_t i = 0; i < size; ++i) v[i] = data[i];
+    return v;
+  }
+
+  template<class... Ts>
+  static auto make(own<Ts>... args) -> own<vec<T>> {
+    T data[] = {args.release()...};
+    return make(sizeof...(Ts), data);
+  }
+
+  template<class U>
+  static auto make(U& x) -> own<vec<T>> {
+    return make(x.length(), x);
+  }
+};
+
+template<>
+inline auto vec<byte_t>::make(size_t size, const byte_t data[]) -> own<vec<byte_t>> {
+  auto v = make(size);
+  if (size != 0) memcpy(v.borrow().data, data, size);
+  return v;
+}
+
+template<class T>
+struct own_vec : vec<T> {
+  ~own_vec() {
+    for (size_t i = 0; i < this->s; ++i) delete this->data[i];
+    delete[] this->data;
+  }
+};
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Type Representations
+
+// Tyoe atributes
+
+enum class mut { CONST, VAR };
+
+struct limits {
+  size_t min;
+  size_t max;
+
+  limits(min, max = SIZE_MAX) : min(min), max(max) {}
+};
+
+
+// Value Types
+
+enum valkind { I32, I64, F32, F64, ANYREF, FUNCREF };
+
+inline bool is_num(valkind k) { return k < ANYREF; }
+inline bool is_ref(valkind k) { return k >= ANYREF; }
+
+
+class valtype {
+public:
+  valtype() = delete;
+  ~valtype();
+
+  static auto make(valkind) -> own<valtype*>;
+  auto clone() const -> own<valtype*>;
+
+  auto kind() const -> valkind;
+  auto is_num() const -> bool { return wasm::is_num(kind()); }
+  auto is_ref() const -> bool { return wasm::is_ref(kind()); }
+};
+
+
+// Function Types
+
+enum class arrow { ARROW };
+
+class functype {
+public:
+  functype() = delete;
+  ~functype();
+
+  static auto make(own<vec<valtype*>> params, own<vec<valtype*>> results) -> own<functype*>;
+
+/*
+  auto make() {
+    return make(vec<valtype*>(), vec<valtype*>());
+  }
+  auto make(std::initializer_list<own<valtype*>> params) {
+    return make(vec<valtype*>::make(params.size(),), vec<valtype*>());
+  }
+*/
+
+  auto clone() const -> own<functype*>;
+
+  auto params() const -> vec<valtype*>;
+  auto results() const -> vec<valtype*>;
+};
+
+
+// Global Types
+
+class globaltype {
+public:
+  globaltype() = delete;
+  ~globaltype();
+
+  static auto make(own<valtype*>, mut) -> own<globaltype*>;
+  auto clone() const -> own<functype*>;
+
+  auto content() const -> valtype*;
+  auto mut() const -> mut;
+};
+
+
+// Table Types
+
+class tabletype {
+public:
+  tabletype() = delete;
+  ~tabletype();
+
+  static auto make(own<valtype*>, limits) -> own<tabletype*>;
+  auto clone() const -> own<tabletype*>;
+
+  auto element() const -> valtype*;
+  auto limits() const -> limits;
+};
+
+
+// Memory Types
+
+class memtype {
+public:
+  memtype() = delete;
+  ~memtype();
+
+  static auto make(limits) -> own<memtype*>;
+  auto clone() const -> own<memtype*>;
+
+  auto limits() const -> limits;
+};
+
+
+// External Types
+
+enum externkind {
+  EXTERN_FUNC, EXTERN_GLOBAL, EXTERN_TABLE, EXTERN_MEMORY
+};
+
+class externtype {
+public:
+  externtype() = delete;
+  ~externtype();
+
+  static auto make(own<functype*>) -> own<externtype*>;
+  static auto make(own<globaltype*>) -> own<externtype*>;
+  static auto make(own<tabletype*>) -> own<externtype*>;
+  static auto make(own<memtype*>) -> own<externtype*>;
+
+  auto clone() const -> own<externtype*>;
+
+  auto kind() const -> externkind;
+  auto func() const -> functype*;
+  auto global() const -> globaltype*;
+  auto table() const -> tabletype*;
+  auto memory() const -> memtype*;
+};
+
+
+// Import Types
+
+using name = vec<byte_t>;
+
+class importtype {
+public:
+  importtype() = delete;
+  ~importtype();
+
+  static auto make(own<name> module, own<name> name, own<externtype*>) -> own<importtype*>;
+  auto clone() const -> own<importtype*>;
+
+  auto module() const -> name;
+  auto name() const -> name;
+  auto type() const -> externtype*;
+};
+
+
+// Export Types
+
+class exporttype {
+public:
+  exporttype() = delete;
+  ~exporttype();
+
+  static auto make(own<name> name, own<externtype*>) -> own<exporttype*>;
+  auto clone() const -> own<exporttype*>;
+
+  auto name() const -> name;
+  auto type() const -> externtype*;
+};
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Runtime Environment
+
+// Initialisation
+
+class config {
+public:
+  config() = delete;
+  ~config();
+
+  static auto make() -> own<config*>;
+
+  // Embedders may provide custom methods for manipulating configs.
+};
+
+void init(int argc, const char* const argv[], own<config*> = config::make());
+void deinit();
+
+
+// Store
+
+class store {
+public:
+  store() = delete;
+  ~store();
+
+  static auto make() -> own<store*>;
+};
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Runtime Objects
+
+// References
+
+template<class T> struct own_ref;
+class ref;
+template<> struct ownership<ref*> { using type = own_ref<ref>; };
+
+class ref {
+public:
+  ref() = delete;
+  ~ref();
+
+  auto clone() const -> own<ref*>;
+
+  auto get_host_info() const -> void*;
+  void set_host_info(void* info, void (*finalizer)(void*) = nullptr);
+};
+
+
+// Values
+
+struct own_val;
+template<> struct ownership<val> { using type = own_val; };
+
+struct val {
+  val() : kind_(ANYREF), ref_(nullptr) {}
+  val(int32_t i) : kind_(I32), i32_(i) {}
+  val(int64_t i) : kind_(I64), i64_(i) {}
+  val(float32_t z) : kind_(F32), f32_(z) {}
+  val(float64_t z) : kind_(F64), f64_(z) {}
+  val(wasm::ref* r) : kind_(ANYREF), ref_(r) {}
+
+  auto kind() const -> valkind { return kind_; }
+  auto i32() const -> int32_t { return kind_ == I32 ? i32_ : 0; }
+  auto i64() const -> int64_t { return kind_ == I64 ? i64_ : 0; }
+  auto f32() const -> float32_t { return kind_ == F32 ? f32_ : 0; }
+  auto f64() const -> float64_t { return kind_ == F64 ? f64_ : 0; }
+  auto ref() const -> wasm::ref* { return is_ref(kind_) ? ref_ : nullptr; }
+
+  auto clone() const -> own<val>;
+
+private:
+  const valkind kind_;
+  union {
+    const int32_t i32_;
+    const int64_t i64_;
+    const float32_t f32_;
+    const float64_t f64_;
+    wasm::ref* ref_;
+  };
+};
+
+struct own_val : val {
+  own_val(val& v) : val(v) {}
+  ~own_val() { if (is_ref(kind_) && ref_ != nullptr) delete ref_; }
+};
+
+
+// Modules
+
+class module;
+template<> struct ownership<module*> { using type = own_ref<module>; };
+
+class module : public ref {
+public:
+  module() = delete;
+  ~module();
+
+  using binary = vec<byte_t>;
+  using serialized = vec<byte_t>;
+
+  static auto make(store*, binary) -> own<module*>;
+  static auto validate(binary) -> bool;
+
+  auto imports() -> own<vec<importtype*>>;
+  auto exports() -> own<vec<exporttype*>>;
+
+  auto serialize() -> own<serialized>;
+  static auto deserialize(serialized) -> own<module*>;
+};
+
+
+// Host Objects
+
+class hostobj;
+template<> struct ownership<hostobj*> { using type = own_ref<hostobj>; };
+
+class hostobj : public ref {
+public:
+  hostobj() = delete;
+  ~hostobj();
+
+  static auto make(store*) -> own<hostobj*>;
+};
+
+
+// Externals
+
+class external;
+template<> struct ownership<external*> { using type = own_ref<external>; };
+
+class external : public ref {
+public:
+  external() = delete;
+  ~external();
+
+  virtual auto kind() const -> externkind = 0;
+
+  template<class T>
+  inline auto to() -> T*;
+};
+
+
+// Function Instances
+
+class func;
+template<> struct ownership<func*> { using type = own_ref<func>; };
+
+class func : public external {
+public:
+  func() = delete;
+  ~func();
+
+  using callback = auto (*)(vec<val>) -> own<vec<val>>;
+  using callback_env = auto (*)(void*, vec<val>) -> own<vec<val>>;
+
+  static auto make(store*, functype*, callback) -> own<func*>;
+  static auto make(store*, functype*, callback_env, void*) -> own<func*>;
+
+  auto kind() const -> externkind override { return EXTERN_FUNC; };
+  auto type() const -> own<functype*>;
+  auto call(vec<val>) const -> own<vec<val>>;
+};
+
+
+// Global Instances
+
+class global;
+template<> struct ownership<global*> { using type = own_ref<global>; };
+
+class global : public external {
+public:
+  global() = delete;
+  ~global();
+
+  static auto make(store*, globaltype*, val) -> own<global*>;
+
+  auto kind() const -> externkind override { return EXTERN_GLOBAL; };
+  auto type() const -> own<globaltype*>;
+  auto get() const -> own<val>;
+  void set(val);
+};
+
+
+// Table Instances
+
+class table;
+template<> struct ownership<table*> { using type = own_ref<table>; };
+
+class table : public external {
+public:
+  table() = delete;
+  ~table();
+
+  using size_t = uint32_t;
+
+  static auto make(store*, tabletype*, ref*) -> own<table*>;
+
+  auto kind() const -> externkind override { return EXTERN_TABLE; };
+  auto type() const -> own<tabletype*>;
+  auto get(size_t index) const -> own<ref*>;
+  void set(size_t index, ref*);
+  auto size() const -> size_t;
+  auto grow(size_t delta) -> size_t;
+};
+
+
+// Memory Instances
+
+class memory;
+template<> struct ownership<memory*> { using type = own_ref<memory>; };
+
+class memory : public external {
+public:
+  memory() = delete;
+  ~memory();
+
+  static auto make(store*, memtype*) -> own<memory*>;
+
+  using pages_t = uint32_t;
+
+  static const size_t page_size = 0x10000;
+
+  auto kind() const -> externkind override { return EXTERN_MEMORY; };
+  auto type() const -> own<memtype*>;
+  auto data() const -> byte_t*;
+  auto data_size() const -> size_t;
+  auto size() const -> pages_t;
+  auto grow(pages_t delta) -> pages_t;
+};
+
+
+// Module Instances
+
+class instance;
+template<> struct ownership<instance*> { using type = own_ref<instance>; };
+
+class instance : public ref {
+public:
+  instance() = delete;
+  ~instance();
+
+  static auto make(store*, module*, vec<external*>) -> own<instance*>;
+
+  auto exports() const -> own<vec<external*>>;
+};
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Convenience
+
+// Value Type construction short-hands
+
+inline own<valtype*> valtype_i32() { return valtype::make(I32); }
+inline own<valtype*> valtype_i64() { return valtype::make(I64); }
+inline own<valtype*> valtype_f32() { return valtype::make(F32); }
+inline own<valtype*> valtype_f64() { return valtype::make(F64); }
+inline own<valtype*> valtype_anyref() { return valtype::make(ANYREF); }
+inline own<valtype*> valtype_funcref() { return valtype::make(FUNCREF); }
+
+
+// Function Types construction short-hands
+
+/*
+
+// Value construction short-hands
+
+inline own wasm_val_t wasm_null_val() {
+  return wasm_ref_val(wasm_ref_null());
+}
+
+inline own wasm_val_t wasm_ptr_val(void* p) {
+#if UINTPTR_MAX == UINT32_MAX
+  return wasm_i32_val((uintptr_t)p);
+#elif UINTPTR_MAX == UINT64_MAX
+  return wasm_i64_val((uintptr_t)p);
+#endif
+}
+
+inline void* wasm_val_ptr(wasm_val_t v) {
+#if UINTPTR_MAX == UINT32_MAX
+  return (void*)(uintptr_t)v.i32;
+#elif UINTPTR_MAX == UINT64_MAX
+  return (void*)(uintptr_t)v.i64;
+#endif
+}
+
+*/
+
+///////////////////////////////////////////////////////////////////////////////
+
+}  // namespave wasm
+
+#endif  // #ifdef __WASM_HH

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -110,6 +110,9 @@ class vec {
     if (!data_) size_ = 0;
   }
 
+  // Unsafe
+  vec(size_t size, T data[]) : size_(size), data_(data) {}
+
 public:
   vec() : size_(0) {}
 
@@ -180,6 +183,11 @@ public:
   static auto make(Ts&&... args) -> vec<T> {
     own<T> data[] = { make_own(args)... };
     return make(sizeof...(Ts), data);
+  }
+
+  // Unsafe
+  static auto adopt(size_t size, T data[]) -> vec<T> {
+    return vec(size, data);
   }
 };
 

--- a/src/wasm-bin.cc
+++ b/src/wasm-bin.cc
@@ -212,22 +212,11 @@ auto imports(vec<byte_t>& binary, vec<wasm::functype*>& types)
     auto name = bin::name(pos);
     own<externtype*> type;
     switch (*pos++) {
-      case 0x00: {
-        auto index = bin::u32(pos);
-        type = externtype::make(types[index]->clone());
-      } break;
-      case 0x01: {
-        type = externtype::make(bin::tabletype(pos));
-      } break;
-      case 0x02: {
-        type = externtype::make(bin::memtype(pos));
-      } break;
-      case 0x03: {
-        type = externtype::make(bin::globaltype(pos));
-      } break;
-      default: {
-        assert(false);
-      }
+      case 0x00: type = types[bin::u32(pos)]->clone(); break;
+      case 0x01: type = bin::tabletype(pos); break;
+      case 0x02: type = bin::memtype(pos); break;
+      case 0x03: type = bin::globaltype(pos); break;
+      default: assert(false);
     }
     v[i] = importtype::make(std::move(module), std::move(name), std::move(type));
   }
@@ -353,21 +342,11 @@ auto exports(vec<byte_t>& binary,
       auto index = bin::u32(pos);
       own<externtype*> type;
       switch (tag) {
-        case 0x00: {
-          type = externtype::make(funcs[index]->clone());
-        } break;
-        case 0x01: {
-          type = externtype::make(tables[index]->clone());
-        } break;
-        case 0x02: {
-          type = externtype::make(memories[index]->clone());
-        } break;
-        case 0x03: {
-          type = externtype::make(globals[index]->clone());
-        } break;
-        default: {
-          assert(false);
-        }
+        case 0x00: type = funcs[index]->clone(); break;
+        case 0x01: type = tables[index]->clone(); break;
+        case 0x02: type = memories[index]->clone(); break;
+        case 0x03: type = globals[index]->clone(); break;
+        default: assert(false);
       }
       exports[i] = exporttype::make(std::move(name), std::move(type));
     }

--- a/src/wasm-bin.cc
+++ b/src/wasm-bin.cc
@@ -260,8 +260,9 @@ for (size_t i = 0; i<4;++i) std::cout << " " << (void*)vv[i]; std::cout <<std::e
 auto vvu = new(std::nothrow) std::unique_ptr<char>[4];
 std::cout << vvu << ": " << std::flush;
 for (size_t i = 0; i<4;++i) std::cout << " " << (void*)vvu[i].get(); std::cout <<std::endl;
-auto vvm = vec<char*>::make(4).data;
-std::cout << (void*)vvm.get() << ": " << std::flush;
+auto vvvm = vec<char*>::make(4);
+auto vvm=vvvm.data.get();
+std::cout << (void*)vvm << ": " << std::flush;
 for (size_t i = 0; i<4;++i) std::cout << " " << (void*)vvm[i]; std::cout <<std::endl;
   auto v = vec<wasm::functype*>::make(size + count(imports, EXTERN_FUNC));
 std::cout << "f " << (v.size - size) << "+" <<size<<"="<<v.size<<" "<<size_t(pos)<<std::endl;
@@ -407,7 +408,7 @@ std::cout << -6 <<std::endl;
 std::cout << -7 <<std::endl;
   auto exports = bin::exports(
     binary, funcs.get(), globals.get(), tables.get(), memories.get());
-std::cout << -8 <<std::endl;
+std::cout << -8 <<" "<<!!imports<<" "<<!!exports<<std::endl;
 
   return std::make_tuple(std::move(imports), std::move(exports));
 }

--- a/src/wasm-bin.cc
+++ b/src/wasm-bin.cc
@@ -188,12 +188,18 @@ auto section(vec<byte_t> binary, bin::sec_t sec) -> const byte_t* {
 // Type section
 
 auto types(vec<byte_t> binary) -> own<vec<wasm::functype*>> {
+std::cout << "t0" <<std::endl;
   auto pos = bin::section(binary, SEC_TYPE);
+std::cout << "t1" <<std::endl;
   if (pos == nullptr) return vec<wasm::functype*>::make();
+std::cout << "t2" <<std::endl;
   size_t size = bin::u32(pos);
+std::cout << "t3 "<<size <<std::endl;
   // TODO(wasm+): support new deftypes
   auto v = vec<wasm::functype*>::make(size);
+std::cout << "t4" <<std::endl;
   for (uint32_t i = 0; i < size; ++i) v.data[i] = bin::functype(pos).release();
+std::cout << "t5" <<std::endl;
   return v;
 }
 

--- a/src/wasm-bin.cc
+++ b/src/wasm-bin.cc
@@ -1,13 +1,12 @@
+#include <iostream>
 #include "wasm-bin.hh"
-
-#define own
 
 namespace wasm {
 namespace bin {
 
 // Numbers
 
-uint32_t u32(const byte_t*& pos) {
+auto u32(const byte_t*& pos) -> uint32_t {
   uint32_t n = 0;
   uint32_t shift = 0;
   byte_t b;
@@ -26,81 +25,82 @@ void u32_skip(const byte_t*& pos) {
 
 // Names
 
-own wasm_name_t name(const byte_t*& pos) {
-  uint32_t len = bin::u32(pos);
+auto name(const byte_t*& pos) -> own<wasm::name> {
+  auto len = bin::u32(pos);
   auto start = pos;
   pos += len;
-  return wasm_name_new(len, start);
+  return name::make(len, start);
 }
 
 void name_skip(const byte_t*& pos) {
-  uint32_t len = bin::u32(pos);
+  auto len = bin::u32(pos);
   pos += len;
 }
 
 
 // Types
 
-own wasm_valtype_t* valtype(const byte_t*& pos) {
+auto valtype(const byte_t*& pos) -> own<wasm::valtype*> {
   switch (*pos++) {
-    case 0x7f: return wasm_valtype_new_i32();
-    case 0x7e: return wasm_valtype_new_i64();
-    case 0x7d: return wasm_valtype_new_f32();
-    case 0x7c: return wasm_valtype_new_f64();
-    case 0x70: return wasm_valtype_new_funcref();
-    case 0x6f: return wasm_valtype_new_anyref();
+    case 0x7f: return valtype::make(I32);
+    case 0x7e: return valtype::make(I64);
+    case 0x7d: return valtype::make(F32);
+    case 0x7c: return valtype::make(F64);
+    case 0x70: return valtype::make(FUNCREF);
+    case 0x6f: return valtype::make(ANYREF);
     default:
       // TODO(wasm+): support new value types
       assert(false);
   }
 }
 
-wasm_mut_t mut(const byte_t*& pos) {
-  return *pos++ ? WASM_VAR : WASM_CONST;
+auto mut(const byte_t*& pos) -> wasm::mut {
+  return *pos++ ? VAR : CONST;
 }
 
-wasm_limits_t limits(const byte_t*& pos) {
-  byte_t tag = *pos++;
+auto limits(const byte_t*& pos) -> limits {
+  auto tag = *pos++;
   auto min = bin::u32(pos);
   if ((tag & 0x01) == 0) {
-    return wasm_limits_no_max(min);
+    return wasm::limits(min);
   } else {
     auto max = bin::u32(pos);
-    return wasm_limits(min, max);
+    return wasm::limits(min, max);
   }
 }
 
-own wasm_functype_t* functype(const byte_t*& pos) {
+auto stacktype(const byte_t*& pos) -> own<vec<wasm::valtype*>> {
+  size_t n = bin::u32(pos);
+  auto v = vec<wasm::valtype*>::make(n);
+  for (uint32_t i = 0; i < n; ++i) {
+    v.data[i] = bin::valtype(pos).release();
+  }
+  return v;
+}
+
+auto functype(const byte_t*& pos) -> own<wasm::functype*> {
   assert(*pos == 0x60);
   ++pos;
-  uint32_t n = bin::u32(pos);
-  auto params = wasm_valtype_vec_new_uninitialized(n);
-  for (uint32_t i = 0; i < n; ++i) {
-    params.data[i] = bin::valtype(pos);
-  }
-  uint32_t m = bin::u32(pos);
-  auto results = wasm_valtype_vec_new_uninitialized(m);
-  for (uint32_t i = 0; i < m; ++i) {
-    results.data[i] = bin::valtype(pos);
-  }
-  return wasm_functype_new(params, results);
+  auto params = bin::stacktype(pos);
+  auto results = bin::stacktype(pos);
+  return functype::make(std::move(params), std::move(results));
 }
 
-own wasm_globaltype_t* globaltype(const byte_t*& pos) {
+auto globaltype(const byte_t*& pos) -> own<wasm::globaltype*> {
   auto content = bin::valtype(pos);
   auto mut = bin::mut(pos);
-  return wasm_globaltype_new(content, mut);
+  return globaltype::make(std::move(content), mut);
 }
 
-own wasm_tabletype_t* tabletype(const byte_t*& pos) {
+auto tabletype(const byte_t*& pos) -> own<wasm::tabletype*> {
   auto elem = bin::valtype(pos);
   auto limits = bin::limits(pos);
-  return wasm_tabletype_new(elem, limits);
+  return tabletype::make(std::move(elem), limits);
 }
 
-own wasm_memtype_t* memtype(const byte_t*& pos) {
+auto memtype(const byte_t*& pos) -> own<wasm::memtype*> {
   auto limits = bin::limits(pos);
-  return wasm_memtype_new(limits);
+  return memtype::make(limits);
 }
 
 
@@ -109,7 +109,7 @@ void mut_skip(const byte_t*& pos) {
 }
 
 void limits_skip(const byte_t*& pos) {
-  byte_t tag = *pos++;
+  auto tag = *pos++;
   bin::u32_skip(pos);
   if ((tag & 0x01) != 0) bin::u32_skip(pos);
 }
@@ -170,12 +170,12 @@ enum sec_t : byte_t {
   SEC_EXPORT = 7
 };
 
-const byte_t* section(wasm_byte_vec_t binary, bin::sec_t sec) {
+auto section(vec<byte_t> binary, bin::sec_t sec) -> const byte_t* {
   const byte_t* end = binary.data + binary.size;
   const byte_t* pos = binary.data + 8;  // skip header
   while (pos < end && *pos != sec) {
     ++pos;
-    uint32_t size = bin::u32(pos);
+    auto size = bin::u32(pos);
     pos += size;
   }
   if (pos == end) return nullptr;
@@ -185,218 +185,225 @@ const byte_t* section(wasm_byte_vec_t binary, bin::sec_t sec) {
 }
 
 
-// Types
+// Type section
 
-own wasm_functype_vec_t types(wasm_byte_vec_t binary) {
+auto types(vec<byte_t> binary) -> own<vec<wasm::functype*>> {
   auto pos = bin::section(binary, SEC_TYPE);
-  if (pos == nullptr) return wasm_functype_vec_empty();
-  uint32_t size = bin::u32(pos);
+  if (pos == nullptr) return vec<wasm::functype*>::make();
+  size_t size = bin::u32(pos);
   // TODO(wasm+): support new deftypes
-  auto v = wasm_functype_vec_new_uninitialized(size);
-  for (uint32_t i = 0; i < size; ++i) v.data[i] = bin::functype(pos);
+  auto v = vec<wasm::functype*>::make(size);
+  for (uint32_t i = 0; i < size; ++i) v.data[i] = bin::functype(pos).release();
   return v;
 }
 
 
-// Imports
+// Import section
 
-own wasm_importtype_vec_t imports(wasm_byte_vec_t binary, wasm_functype_vec_t types) {
+auto imports(vec<byte_t> binary, vec<wasm::functype*> types) -> own<vec<importtype*>> {
   auto pos = bin::section(binary, SEC_IMPORT);
-  if (pos == nullptr) return wasm_importtype_vec_empty();
-  uint32_t size = bin::u32(pos);
-  auto v = wasm_importtype_vec_new_uninitialized(size);
+  if (pos == nullptr) return vec<importtype*>::make();
+  size_t size = bin::u32(pos);
+  auto v = vec<importtype*>::make(size);
   for (uint32_t i = 0; i < size; ++i) {
     auto module = bin::name(pos);
     auto name = bin::name(pos);
-    own wasm_externtype_t* type;
+    own<externtype*> type;
     switch (*pos++) {
       case 0x00: {
-        uint32_t index = bin::u32(pos);
-        type = wasm_functype_as_externtype(wasm_functype_clone(types.data[index]));
+        auto index = bin::u32(pos);
+        type = externtype::make(types.data[index]->clone());
       } break;
       case 0x01: {
-        type = wasm_tabletype_as_externtype(bin::tabletype(pos));
+        type = externtype::make(bin::tabletype(pos));
       } break;
       case 0x02: {
-        type = wasm_memtype_as_externtype(bin::memtype(pos));
+        type = externtype::make(bin::memtype(pos));
       } break;
       case 0x03: {
-        type = wasm_globaltype_as_externtype(bin::globaltype(pos));
+        type = externtype::make(bin::globaltype(pos));
       } break;
       default: {
         assert(false);
       }
     }
-    v.data[i] = wasm_importtype_new(module, name, type);
+    v.data[i] = importtype::make(std::move(module), std::move(name), std::move(type)).release();
   }
   return v;
 }
 
+auto count(vec<importtype*> imports, externkind kind) -> uint32_t {
+  uint32_t n = 0;
+  for (uint32_t i = 0; i < imports.size; ++i) {
+    if (imports.data[i]->type()->kind() == kind) ++n;
+  }
+  return n;
+}
 
-// Functions
 
-own wasm_functype_vec_t funcs(wasm_byte_vec_t binary, wasm_importtype_vec_t imports, wasm_functype_vec_t types) {
+// Function section
+
+auto funcs(vec<byte_t> binary, vec<importtype*> imports, vec<wasm::functype*> types) -> own<vec<wasm::functype*>> {
   auto pos = bin::section(binary, SEC_FUNC);
+std::cout << "f0 " <<size_t(pos)<<std::endl;
   size_t size = pos != nullptr ? bin::u32(pos) : 0;
-  for (uint32_t i = 0; i < imports.size; ++i) {
-    auto et = wasm_importtype_type(imports.data[i]);
-    if (wasm_externtype_kind(et) == WASM_EXTERN_FUNC) ++size;
-  }
-  own auto v = wasm_functype_vec_new_uninitialized(size);
+using charp=char*;
+auto vv = new(std::nothrow) charp[4];
+std::cout << vv << ": " << std::flush;
+for (size_t i = 0; i<4;++i) std::cout << " " << (void*)vv[i]; std::cout <<std::endl;
+auto vvu = new(std::nothrow) std::unique_ptr<char>[4];
+std::cout << vvu << ": " << std::flush;
+for (size_t i = 0; i<4;++i) std::cout << " " << (void*)vvu[i].get(); std::cout <<std::endl;
+auto vvm = vec<char*>::make(4).data;
+std::cout << (void*)vvm.get() << ": " << std::flush;
+for (size_t i = 0; i<4;++i) std::cout << " " << (void*)vvm[i]; std::cout <<std::endl;
+  auto v = vec<wasm::functype*>::make(size + count(imports, EXTERN_FUNC));
+std::cout << "f " << (v.size - size) << "+" <<size<<"="<<v.size<<" "<<size_t(pos)<<std::endl;
+for (size_t i = 0; i<v.size;++i) std::cout << " " << v.data[i]; std::cout <<std::endl;
   size_t j = 0;
-
   for (uint32_t i = 0; i < imports.size; ++i) {
-    auto et = wasm_importtype_type(imports.data[i]);
-    if (wasm_externtype_kind(et) == WASM_EXTERN_FUNC) {
-      v.data[j++] = wasm_externtype_as_functype(et);
-    } 
+    auto et = imports.data[i]->type();
+    if (et->kind() == EXTERN_FUNC) v.data[j++] = et->func()->clone().release();
   }
+std::cout << "f' " << j <<" " <<size_t(pos)<<std::endl;
   if (pos != nullptr) {
-    for (; j < size; ++j) {
-      uint32_t index = bin::u32(pos);
-      v.data[j] = types.data[index];
-    }
+    for (; j < v.size; ++j) v.data[j] = types.data[bin::u32(pos)]->clone().release();
   }
+std::cout << "f'' " << j <<std::endl;
   return v;
 }
 
 
-// Globals
+// Global section
 
-own wasm_globaltype_vec_t globals(wasm_byte_vec_t binary, wasm_importtype_vec_t imports) {
+auto globals(vec<byte_t> binary, vec<importtype*> imports) -> own<vec<wasm::globaltype*>> {
   auto pos = bin::section(binary, SEC_GLOBAL);
   size_t size = pos != nullptr ? bin::u32(pos) : 0;
-  for (uint32_t i = 0; i < imports.size; ++i) {
-    auto et = wasm_importtype_type(imports.data[i]);
-    if (wasm_externtype_kind(et) == WASM_EXTERN_GLOBAL) ++size;
-  }
-  own auto v = wasm_globaltype_vec_new_uninitialized(size);
+  auto v = vec<wasm::globaltype*>::make(size + count(imports, EXTERN_GLOBAL));
   size_t j = 0;
-
   for (uint32_t i = 0; i < imports.size; ++i) {
-    auto et = wasm_importtype_type(imports.data[i]);
-    if (wasm_externtype_kind(et) == WASM_EXTERN_GLOBAL) {
-      v.data[j++] = wasm_globaltype_clone(wasm_externtype_as_globaltype(et));
-    } 
+    auto et = imports.data[i]->type();
+    if (et->kind() == EXTERN_GLOBAL) v.data[j++] = et->global()->clone().release();
   }
   if (pos != nullptr) {
-    for (; j < size; ++j) {
-      v.data[j] = bin::globaltype(pos);
-    }
+    for (; j < size; ++j) v.data[j] = bin::globaltype(pos).release();
   }
   return v;
 }
 
 
-// Tables
+// Table section
 
-own wasm_tabletype_vec_t tables(wasm_byte_vec_t binary, wasm_importtype_vec_t imports) {
+auto tables(vec<byte_t> binary, vec<importtype*> imports) -> own<vec<wasm::tabletype*>> {
   auto pos = bin::section(binary, SEC_TABLE);
   size_t size = pos != nullptr ? bin::u32(pos) : 0;
-  for (uint32_t i = 0; i < imports.size; ++i) {
-    auto et = wasm_importtype_type(imports.data[i]);
-    if (wasm_externtype_kind(et) == WASM_EXTERN_TABLE) ++size;
-  }
-  own auto v = wasm_tabletype_vec_new_uninitialized(size);
+  auto v = vec<wasm::tabletype*>::make(size + count(imports, EXTERN_TABLE));
   size_t j = 0;
-
   for (uint32_t i = 0; i < imports.size; ++i) {
-    auto et = wasm_importtype_type(imports.data[i]);
-    if (wasm_externtype_kind(et) == WASM_EXTERN_TABLE) {
-      v.data[j++] = wasm_tabletype_clone(wasm_externtype_as_tabletype(et));
-    } 
+    auto et = imports.data[i]->type();
+    if (et->kind() == EXTERN_TABLE) v.data[j++] = et->table()->clone().release();
   }
   if (pos != nullptr) {
-    for (; j < size; ++j) {
-      v.data[j] = bin::tabletype(pos);
-    }
+    for (; j < size; ++j) v.data[j] = bin::tabletype(pos).release();
   }
   return v;
 }
 
 
-// Memories
+// Memory section
 
-own wasm_memtype_vec_t memories(wasm_byte_vec_t binary, wasm_importtype_vec_t imports) {
+auto memories(vec<byte_t> binary, vec<importtype*> imports) -> own<vec<wasm::memtype*>> {
   auto pos = bin::section(binary, SEC_MEMORY);
   size_t size = pos != nullptr ? bin::u32(pos) : 0;
-  for (uint32_t i = 0; i < imports.size; ++i) {
-    auto et = wasm_importtype_type(imports.data[i]);
-    if (wasm_externtype_kind(et) == WASM_EXTERN_MEMORY) ++size;
-  }
-  own auto v = wasm_memtype_vec_new_uninitialized(size);
+  auto v = vec<wasm::memtype*>::make(size + count(imports, EXTERN_MEMORY));
   size_t j = 0;
-
   for (uint32_t i = 0; i < imports.size; ++i) {
-    auto et = wasm_importtype_type(imports.data[i]);
-    if (wasm_externtype_kind(et) == WASM_EXTERN_MEMORY) {
-      v.data[j++] = wasm_memtype_clone(wasm_externtype_as_memtype(et));
-    } 
+    auto et = imports.data[i]->type();
+    if (et->kind() == EXTERN_MEMORY) v.data[j++] = et->memory()->clone().release();
   }
   if (pos != nullptr) {
-    for (; j < size; ++j) {
-      v.data[j] = bin::memtype(pos);
-    }
+    for (; j < size; ++j) v.data[j] = bin::memtype(pos).release();
   }
   return v;
 }
 
 
-// Exports
+// Export section
 
-own wasm_exporttype_vec_t exports(wasm_byte_vec_t binary,
-  wasm_functype_vec_t funcs, wasm_globaltype_vec_t globals,
-  wasm_tabletype_vec_t tables, wasm_memtype_vec_t memories
-) {
-  own auto exports = wasm_exporttype_vec_empty();
+auto exports(vec<byte_t> binary,
+  vec<wasm::functype*> funcs, vec<wasm::globaltype*> globals,
+  vec<wasm::tabletype*> tables, vec<wasm::memtype*> memories
+) -> own<vec<exporttype*>> {
+  auto exports = vec<exporttype*>::make();
+std::cout << "a1" <<std::endl;
+for (size_t i = 0; i<funcs.size;++i) std::cout << " " << funcs.data[i]; std::cout <<std::endl;
   auto pos = bin::section(binary, SEC_EXPORT);
+std::cout << "a2" <<std::endl;
   if (pos != nullptr) {
-    uint32_t size = bin::u32(pos);
-    exports = wasm_exporttype_vec_new_uninitialized(size);
+std::cout << "a3" <<std::endl;
+    size_t size = bin::u32(pos);
+    exports = vec<exporttype*>::make(size);
+std::cout << "a4" <<std::endl;
     for (uint32_t i = 0; i < size; ++i) {
+std::cout << "a5 " <<i <<std::endl;
       auto name = bin::name(pos);
+std::cout << "a6 " << std::string(name.data.get(), name.size) <<std::endl;
       auto tag = *pos++;
       auto index = bin::u32(pos);
-      own wasm_externtype_t* type;
+std::cout << "a7 " <<index <<std::endl;
+      own<externtype*> type;
       switch (tag) {
         case 0x00: {
-          type = wasm_functype_as_externtype(wasm_functype_clone(funcs.data[index]));
+std::cout << "a1 " <<funcs.data[index] <<std::endl;
+          type = externtype::make(funcs.data[index]->clone());
+std::cout << "a1" <<std::endl;
         } break;
         case 0x01: {
-          type = wasm_tabletype_as_externtype(wasm_tabletype_clone(tables.data[index]));
+std::cout << "a2" <<std::endl;
+          type = externtype::make(tables.data[index]->clone());
         } break;
         case 0x02: {
-          type = wasm_memtype_as_externtype(wasm_memtype_clone(memories.data[index]));
+std::cout << "a4" <<std::endl;
+          type = externtype::make(memories.data[index]->clone());
         } break;
         case 0x03: {
-          type = wasm_globaltype_as_externtype(wasm_globaltype_clone(globals.data[index]));
+std::cout << "a5" <<std::endl;
+          type = externtype::make(globals.data[index]->clone());
         } break;
         default: {
           assert(false);
         }
       }
-      exports.data[i] = wasm_exporttype_new(name, type);
+std::cout << "a8" <<std::endl;
+      exports.data[i] = exporttype::make(std::move(name), std::move(type)).release();
+std::cout << "a9" <<std::endl;
     }
   }
+std::cout << "a10" <<std::endl;
   return exports;
 }
 
-std::tuple<own wasm_importtype_vec_t, own wasm_exporttype_vec_t>
-imports_exports(wasm_byte_vec_t binary) {
+auto imports_exports(vec<byte_t> binary
+) -> std::tuple<own<vec<importtype*>>, own<vec<exporttype*>>> {
+std::cout << -1 <<std::endl;
   auto types = bin::types(binary);
-  auto imports = bin::imports(binary, types);
-  auto funcs = bin::funcs(binary, imports, types);
-  auto globals = bin::globals(binary, imports);
-  auto tables = bin::tables(binary, imports);
-  auto memories = bin::memories(binary, imports);
-  auto exports = bin::exports(binary, funcs, globals, tables, memories);
+std::cout << -2 <<std::endl;
+  auto imports = bin::imports(binary, types.get());
+std::cout << -3 <<std::endl;
+  auto funcs = bin::funcs(binary, imports.get(), types.get());
+std::cout << -4 <<std::endl;
+for (size_t i = 0; i<funcs.size;++i) std::cout << " " << funcs.data[i]; std::cout <<std::endl;
+  auto globals = bin::globals(binary, imports.get());
+std::cout << -5 <<std::endl;
+  auto tables = bin::tables(binary, imports.get());
+std::cout << -6 <<std::endl;
+  auto memories = bin::memories(binary, imports.get());
+std::cout << -7 <<std::endl;
+  auto exports = bin::exports(
+    binary, funcs.get(), globals.get(), tables.get(), memories.get());
+std::cout << -8 <<std::endl;
 
-  wasm_functype_vec_delete(types);
-  if (funcs.data) delete[] funcs.data;
-  wasm_globaltype_vec_delete(globals);
-  wasm_tabletype_vec_delete(tables);
-  wasm_memtype_vec_delete(memories);
-  return std::make_tuple(imports, exports);
+  return std::make_tuple(std::move(imports), std::move(exports));
 }
 
 }  // namespace bin

--- a/src/wasm-bin.hh
+++ b/src/wasm-bin.hh
@@ -1,18 +1,16 @@
-#ifndef __WASM_BIN_H
-#define __WASM_BIN_H
+#ifndef __WASM_BIN_HH
+#define __WASM_BIN_HH
 
-#include "wasm.h"
+#include "wasm.hh"
 #include <tuple>
-
-#define own
 
 namespace wasm {
 namespace bin {
 
-std::tuple<own wasm_importtype_vec_t, own wasm_exporttype_vec_t>
-imports_exports(wasm_byte_vec_t binary);
+auto imports_exports(module::binary) ->
+  std::tuple<own<vec<importtype*>>, own<vec<exporttype*>>>;
 
 }  // namespace bin
 }  // namespace wasm
 
-#endif  // #ifdef __WASM_BIN_H
+#endif  // #ifdef __WASM_BIN_HH

--- a/src/wasm-bin.hh
+++ b/src/wasm-bin.hh
@@ -7,8 +7,8 @@
 namespace wasm {
 namespace bin {
 
-auto imports_exports(module::binary) ->
-  std::tuple<own<vec<importtype*>>, own<vec<exporttype*>>>;
+auto imports_exports(vec<byte_t>& binary) ->
+  std::tuple<vec<importtype*>, vec<exporttype*>>;
 
 }  // namespace bin
 }  // namespace wasm

--- a/src/wasm-c.cc
+++ b/src/wasm-c.cc
@@ -1,0 +1,1068 @@
+#include "wasm.h"
+#include "wasm.hh"
+
+using namespace wasm;
+
+extern "C" {
+
+///////////////////////////////////////////////////////////////////////////////
+// Auxiliaries
+
+// Backing implementation
+
+extern "C++" {
+
+template<class T>
+struct borrowed {
+  own<T> it;
+  borrowed(T x) : it(x) {}
+  borrowed(borrowed<T>&& that) : it(std::move(that)) {}
+  ~borrowed() { it.release(); }
+};
+
+template<class T>
+struct borrowed_vec {
+  vec<T> it;
+  borrowed_vec(vec<T>&& v) : it(v.release()) {}
+  borrowed_vec(borrowed_vec<T>&& that) : it(std::move(that)) {}
+  ~borrowed_vec() { it.release(); }
+};
+
+}  // extern "C++"
+
+
+#define WASM_DEFINE_OWN(name) \
+  struct wasm_##name##_t : wasm::name {}; \
+  \
+  void wasm_##name##_delete(wasm_##name##_t* x) { \
+    delete x; \
+  } \
+  \
+  extern "C++" inline auto hide(wasm::name* x) -> wasm_##name##_t* { \
+    return static_cast<wasm_##name##_t*>(x); \
+  } \
+  extern "C++" inline auto reveal(wasm_##name##_t* x) -> wasm::name* { \
+    return x; \
+  } \
+  extern "C++" inline auto get(own<wasm::name*>& x) -> wasm_##name##_t* { \
+    return hide(x.get()); \
+  } \
+  extern "C++" inline auto release(own<wasm::name*>&& x) -> wasm_##name##_t* { \
+    return hide(x.release()); \
+  } \
+  extern "C++" inline auto adopt(wasm_##name##_t* x) -> own<wasm::name*> { \
+    return make_own(x); \
+  } \
+  extern "C++" inline auto borrow(wasm_##name##_t* x) -> borrowed<name*> { \
+    return borrowed<name*>(x); \
+  }
+
+
+// Vectors
+
+#define WASM_DEFINE_VEC_BASE(name, ptr_or_none) \
+  extern "C++" inline auto hide(name ptr_or_none* v) -> wasm_##name##_t ptr_or_none* { \
+    return reinterpret_cast<wasm_##name##_t ptr_or_none*>(v); \
+  } \
+  extern "C++" inline auto reveal(wasm_##name##_t ptr_or_none* v) -> name ptr_or_none* { \
+    return reinterpret_cast<name ptr_or_none*>(v); \
+  } \
+  extern "C++" inline auto get(wasm::vec<name ptr_or_none>& v) -> wasm_##name##_vec_t { \
+    return wasm_##name##_vec(v.size(), hide(v.get())); \
+  } \
+  extern "C++" inline auto release(wasm::vec<name ptr_or_none>&& v) -> wasm_##name##_vec_t { \
+    return wasm_##name##_vec(v.size(), hide(v.release())); \
+  } \
+  extern "C++" inline auto adopt(wasm_##name##_vec_t v) -> wasm::vec<name ptr_or_none> { \
+    return wasm::vec<name ptr_or_none>::adopt(v.size, reveal(v.data)); \
+  } \
+  extern "C++" inline auto borrow_vec(wasm_##name##_vec_t v) -> borrowed_vec<name ptr_or_none> { \
+    return borrowed_vec<name ptr_or_none>(wasm::vec<name ptr_or_none>::adopt(v.size, reveal(v.data))); \
+  } \
+  \
+  wasm_##name##_vec_t wasm_##name##_vec_new_uninitialized(size_t size) { \
+    return release(wasm::vec<name ptr_or_none>::make_uninitialized(size)); \
+  } \
+  wasm_##name##_vec_t wasm_##name##_vec_new_empty() { \
+    return wasm_##name##_vec_new_uninitialized(0); \
+  }
+
+// Vectors with no ownership management of elements
+#define WASM_DEFINE_VEC_PLAIN(name, ptr_or_none) \
+  WASM_DEFINE_VEC_BASE(name, ptr_or_none) \
+  \
+  wasm_##name##_vec_t wasm_##name##_vec_new(size_t size, wasm_##name##_t ptr_or_none const data[]) { \
+    auto v2 = wasm::vec<name ptr_or_none>::make_uninitialized(size); \
+    if (v2.size() != 0) memcpy(v2.get(), data, size * sizeof(wasm_##name##_t ptr_or_none)); \
+    return release(std::move(v2)); \
+  } \
+  \
+  wasm_##name##_vec_t wasm_##name##_vec_clone(wasm_##name##_vec_t v) { \
+    return wasm_##name##_vec_new(v.size, v.data); \
+  } \
+  \
+  void wasm_##name##_vec_delete(wasm_##name##_vec_t v) { \
+    if (v.data) delete[] v.data; \
+  }
+
+// Vectors who own their elements
+#define WASM_DEFINE_VEC(name, ptr_or_none) \
+  WASM_DEFINE_VEC_BASE(name, ptr_or_none) \
+  \
+  wasm_##name##_vec_t wasm_##name##_vec_new(size_t size, wasm_##name##_t ptr_or_none const data[]) { \
+    auto v2 = wasm::vec<name ptr_or_none>::make_uninitialized(size); \
+    for (size_t i = 0; i < v2.size(); ++i) { \
+      v2[i] = adopt(data[i]); \
+    } \
+    return release(std::move(v2)); \
+  } \
+  \
+  wasm_##name##_vec_t wasm_##name##_vec_clone(wasm_##name##_vec_t v) { \
+    auto v2 = wasm::vec<name ptr_or_none>::make_uninitialized(v.size); \
+    for (size_t i = 0; i < v2.size(); ++i) { \
+      v2[i] = v.data[i]->clone(); \
+    } \
+    return release(std::move(v2)); \
+  } \
+  \
+  void wasm_##name##_vec_delete(wasm_##name##_vec_t v) { \
+    if (v.data) { \
+      for (size_t i = 0; i < v.size; ++i) { \
+        if (v.data[i]) wasm_##name##_delete(v.data[i]); \
+      } \
+      delete[] v.data; \
+    } \
+  }
+
+
+// Byte vectors
+
+using byte = byte_t;
+WASM_DEFINE_VEC_PLAIN(byte, )
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Runtime Environment
+
+// Configuration
+
+WASM_DEFINE_OWN(config)
+
+wasm_config_t* wasm_config_new() {
+  return release(config::make());
+}
+
+
+// Engine
+
+WASM_DEFINE_OWN(engine)
+
+wasm_engine_t* wasm_engine_new(int argc, const char *const argv[]) {
+  return release(engine::make(argc, argv));
+}
+
+wasm_engine_t* wasm_engine_new_with_config(
+  int argc, const char *const argv[], wasm_config_t* config
+) {
+  return release(engine::make(argc, argv, adopt(config)));
+}
+
+
+// Stores
+
+WASM_DEFINE_OWN(store)
+
+wasm_store_t* wasm_store_new(wasm_engine_t* engine) {
+  auto engine_ = borrow(engine);
+  return release(store::make(engine_.it));
+};
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Type Representations
+
+// Type attributes
+
+extern "C++" inline auto hide(wasm::mut mut) -> wasm_mut_t {
+  return static_cast<wasm_mut_t>(mut);
+}
+
+extern "C++" inline auto reveal(wasm_mut_t mut) -> wasm::mut {
+  return static_cast<wasm::mut>(mut);
+}
+
+
+extern "C++" inline auto hide(wasm::limits limits) -> wasm_limits_t {
+  return wasm_limits(limits.min, limits.max);
+}
+
+extern "C++" inline auto reveal(wasm_limits_t limits) -> wasm::limits {
+  return wasm::limits(limits.min, limits.max);
+}
+
+
+extern "C++" inline auto hide(wasm::valkind kind) -> wasm_valkind_t {
+  return static_cast<wasm_valkind_t>(kind);
+}
+
+extern "C++" inline auto reveal(wasm_valkind_t kind) -> wasm::valkind {
+  return static_cast<wasm::valkind>(kind);
+}
+
+
+extern "C++" inline auto hide(wasm::externkind kind) -> wasm_externkind_t {
+  return static_cast<wasm_externkind_t>(kind);
+}
+
+extern "C++" inline auto reveal(wasm_externkind_t kind) -> wasm::externkind {
+  return static_cast<wasm::externkind>(kind);
+}
+
+
+
+// Generic
+
+#define WASM_DEFINE_TYPE(name) \
+  WASM_DEFINE_OWN(name) \
+  WASM_DEFINE_VEC(name, *) \
+  \
+  wasm_##name##_t* wasm_##name##_clone(wasm_##name##_t* t) { \
+    return release(t->clone()); \
+  }
+
+
+// Value Types
+
+WASM_DEFINE_TYPE(valtype)
+
+wasm_valtype_t* wasm_valtype_new(wasm_valkind_t k) {
+  return release(valtype::make(reveal(k)));
+}
+
+wasm_valkind_t wasm_valtype_kind(wasm_valtype_t* t) {
+  return hide(t->kind());
+}
+
+
+// Function Types
+
+WASM_DEFINE_TYPE(functype)
+
+wasm_functype_t* wasm_functype_new(wasm_valtype_vec_t params, wasm_valtype_vec_t results) {
+  return release(functype::make(adopt(params), adopt(results)));
+}
+
+wasm_valtype_vec_t wasm_functype_params(wasm_functype_t* ft) {
+  return get(ft->params());
+}
+
+wasm_valtype_vec_t wasm_functype_results(wasm_functype_t* ft) {
+  return get(ft->results());
+}
+
+
+// Global Types
+
+WASM_DEFINE_TYPE(globaltype)
+
+wasm_globaltype_t* wasm_globaltype_new(wasm_valtype_t* content, wasm_mut_t mut) {
+  return release(globaltype::make(adopt(content), reveal(mut)));
+}
+
+wasm_valtype_t* wasm_globaltype_content(wasm_globaltype_t* gt) {
+  return get(gt->content());
+}
+
+wasm_mut_t wasm_globaltype_mut(wasm_globaltype_t* gt) {
+  return hide(gt->mut());
+}
+
+
+// Table Types
+
+WASM_DEFINE_TYPE(tabletype)
+
+wasm_tabletype_t* wasm_tabletype_new(wasm_valtype_t* elem, wasm_limits_t limits) {
+  return release(tabletype::make(adopt(elem), reveal(limits)));
+}
+
+wasm_valtype_t* wasm_tabletype_elem(wasm_tabletype_t* tt) {
+  return get(tt->element());
+}
+
+wasm_limits_t wasm_tabletype_limits(wasm_tabletype_t* tt) {
+  return hide(tt->limits());
+}
+
+
+// Memory Types
+
+WASM_DEFINE_TYPE(memtype)
+
+wasm_memtype_t* wasm_memtype_new(wasm_limits_t limits) {
+  return release(memtype::make(reveal(limits)));
+}
+
+wasm_limits_t wasm_memtype_limits(wasm_memtype_t* mt) {
+  return hide(mt->limits());
+}
+
+
+// Extern Types
+
+WASM_DEFINE_TYPE(externtype)
+
+wasm_externtype_t* wasm_functype_as_externtype(wasm_functype_t* ft) {
+  return hide(static_cast<externtype*>(ft));
+}
+wasm_externtype_t* wasm_globaltype_as_externtype(wasm_globaltype_t* gt) {
+  return hide(static_cast<externtype*>(gt));
+}
+wasm_externtype_t* wasm_tabletype_as_externtype(wasm_tabletype_t* tt) {
+  return hide(static_cast<externtype*>(tt));
+}
+wasm_externtype_t* wasm_memtype_as_externtype(wasm_memtype_t* mt) {
+  return hide(static_cast<externtype*>(mt));
+}
+
+wasm_functype_t* wasm_externtype_as_functype(wasm_externtype_t* et) {
+  return et->kind() == EXTERN_FUNC ? hide(static_cast<functype*>(reveal(et))) : nullptr;
+}
+wasm_globaltype_t* wasm_externtype_as_globaltype(wasm_externtype_t* et) {
+  return et->kind() == EXTERN_GLOBAL ? hide(static_cast<globaltype*>(reveal(et))) : nullptr;
+}
+wasm_tabletype_t* wasm_externtype_as_tabletype(wasm_externtype_t* et) {
+  return et->kind() == EXTERN_TABLE ? hide(static_cast<tabletype*>(reveal(et))) : nullptr;
+}
+wasm_memtype_t* wasm_externtype_as_memtype(wasm_externtype_t* et) {
+  return et->kind() == EXTERN_MEMORY ? hide(static_cast<memtype*>(reveal(et))) : nullptr;
+}
+
+wasm_externkind_t wasm_externtype_kind(wasm_externtype_t* et) {
+  return hide(et->kind());
+}
+
+
+// Import Types
+
+WASM_DEFINE_TYPE(importtype)
+
+wasm_importtype_t* wasm_importtype_new(wasm_name_t module, wasm_name_t name, wasm_externtype_t* type) {
+  return release(importtype::make(adopt(module), adopt(name), adopt(type)));
+}
+
+wasm_name_t wasm_importtype_module(wasm_importtype_t* it) {
+  return get(it->module());
+}
+
+wasm_name_t wasm_importtype_name(wasm_importtype_t* it) {
+  return get(it->name());
+}
+
+wasm_externtype_t* wasm_importtype_type(wasm_importtype_t* it) {
+  return get(it->type());
+}
+
+
+// Export Types
+
+WASM_DEFINE_TYPE(exporttype)
+
+wasm_exporttype_t* wasm_exporttype_new(wasm_name_t name, wasm_externtype_t* type) {
+  return release(exporttype::make(adopt(name), adopt(type)));
+}
+
+wasm_name_t wasm_exporttype_name(wasm_exporttype_t* et) {
+  return get(et->name());
+}
+
+wasm_externtype_t* wasm_exporttype_type(wasm_exporttype_t* et) {
+  return get(et->type());
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Runtime Values
+
+// Values
+
+WASM_DEFINE_VEC(val, )
+
+void wasm_val_delete(wasm_val_t val) {
+  delete_own(val);
+}
+
+own wasm_val_t wasm_val_clone(wasm_val_t val) {
+  if (wasm_valkind_is_refkind(val.kind)) {
+    val.ref = wasm_ref_clone(val.ref);
+  }
+  return val;
+}
+
+extern "C++" inline auto hide(wasm::val v) -> wasm_val_t {
+  wasm_val_t v2 = { hide(v.kind()) };
+  switch (v.kind()) {
+    case I32: v2.i32 = v.i32(); break;
+    case I64: v2.i64 = v.i64(); break;
+    case F32: v2.f32 = v.f32(); break;
+    case F64: v2.f64 = v.f64(); break;
+    case ANYREF:
+    case FUNCREF: v2.ref = v.release(); break;
+    default: assert(false);
+  }
+  return v2;
+}
+
+extern "C++" inline auto reveal(wasm_val_t v) -> wasm::val {
+  switch (reveal(v.kind)) {
+    case I32: return val(v.i32);
+    case I64: return val(v.i64);
+    case F32: return val(v.f32);
+    case F64: return val(v.f64);
+    case ANYREF:
+    case FUNCREF: return val(adopt(v.ref));
+    default: assert(false);
+  }
+}
+
+extern "C++" inline auto get(val v) -> wasm_##name##_t* {
+
+  return hide(x.get());
+  } \
+  extern "C++" inline auto release(own<wasm::name*>&& x) -> wasm_##name##_t* { \
+    return hide(x.release()); \
+  } \
+  extern "C++" inline auto adopt(wasm_##name##_t* x) -> own<wasm::name*> { \
+    return make_own(x); \
+  } \
+  extern "C++" inline auto borrow(wasm_##name##_t* x) -> borrowed<name*> { \
+    return borrowed<name*>(x); \
+  }
+
+
+// References
+
+WASM_DEFINE_OWN(ref)
+
+wasm_ref_t* wasm_ref_clone(wasm_ref_t* r) {
+  return release(r->clone());
+}
+
+
+#define WASM_DEFINE_REF(name) \
+  WASM_DEFINE_OWN(name) \
+  \
+  wasm_##name##_t* wasm_##name##_clone(wasm_##name##_t* t) { \
+    return release(t->clone()); \
+  } \
+  \
+  wasm_ref_t* wasm_##name##_as_ref(wasm_##name##_t* r) { \
+    return hide(static_cast<ref*>(reveal(r))); \
+  } \
+  wasm_##name##_t* wasm_ref_as_##name(wasm_ref_t* r) { \
+    return hide(static_cast<name*>(reveal(r))); \
+  } \
+  \
+  void* wasm_##name##_get_host_info(wasm_##name##_t* r) { \
+    return r->get_host_info(); \
+  } \
+  void wasm_##name##_set_host_info(wasm_##name##_t* r, void* info) { \
+    r->set_host_info(info); \
+  } \
+  void wasm_##name##_set_host_info_with_finalizer( \
+    wasm_##name##_t* r, void* info, void (*finalizer)(void*) \
+  ) { \
+    r->set_host_info(info, finalizer); \
+  }
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Runtime Objects
+
+// Modules
+
+struct wasm_module_t : wasm_ref_t {
+  owned<wasm_importtype_vec_t> imports;
+  owned<wasm_exporttype_vec_t> exports;
+
+  wasm_module_t(wasm_store_t* store, v8::Local<v8::Object> obj,
+    own wasm_importtype_vec_t imports, own wasm_exporttype_vec_t exports) :
+    wasm_ref_t(store, obj), imports(imports), exports(exports) {}
+};
+
+WASM_DEFINE_REF(module)
+
+own wasm_module_t* wasm_module_new(wasm_store_t* store, wasm_byte_vec_t binary) {
+  auto isolate = store->isolate();
+  auto context = store->context();
+  v8::HandleScope handle_scope(isolate);
+
+  auto array_buffer = v8::ArrayBuffer::New(isolate, binary.data, binary.size);
+
+  v8::Local<v8::Value> args[] = {array_buffer};
+  auto maybe_obj =
+    store->v8_function(V8_F_MODULE)->NewInstance(context, 1, args);
+  if (maybe_obj.IsEmpty()) return nullptr;
+  auto obj = maybe_obj.ToLocalChecked();
+
+  // TODO(wasm+): use JS API once available?
+  auto imports_exports = wasm::bin::imports_exports(binary);
+  // TODO store->cache_set(module_obj, module);
+  return new wasm_module_t(store, obj, std::get<0>(imports_exports), std::get<1>(imports_exports));
+}
+
+bool wasm_module_validate(wasm_store_t* store, wasm_byte_vec_t binary) {
+  v8::Isolate* isolate = store->isolate();
+  v8::HandleScope handle_scope(isolate);
+
+  auto array_buffer = v8::ArrayBuffer::New(isolate, binary.data, binary.size);
+
+  v8::Local<v8::Value> args[] = {array_buffer};
+  auto result = store->v8_function(V8_F_VALIDATE)->Call(
+    store->context(), v8::Undefined(isolate), 1, args);
+  if (result.IsEmpty()) return false;
+
+  return result.ToLocalChecked()->IsTrue();
+}
+
+
+wasm_importtype_vec_t wasm_module_imports(wasm_module_t* module) {
+  return module->imports.borrow();
+/* OBSOLETE?
+  auto store = module->store();
+  auto isolate = store->isolate();
+  auto context = store->context();
+  v8::HandleScope handle_scope(isolate);
+
+  v8::Local<v8::Value> args[] = { module->v8_object() };
+  auto result = store->v8_function(V8_F_IMPORTS)->Call(
+    context, v8::Undefined(isolate), 1, args);
+  if (result.IsEmpty()) return wasm_importtype_vec_empty();
+  auto array = v8::Local<v8::Array>::Cast(result.ToLocalChecked());
+  size_t size = array->Length();
+
+  wasm_importtype_vec_t imports = wasm_importtype_vec_new_uninitialized(size);
+  for (size_t i = 0; i < size; ++i) {
+    auto desc = v8::Local<v8::Object>::Cast(array->Get(i));
+    auto module_str = v8::Local<v8::String>::Cast(
+      desc->Get(context, store->v8_string(V8_S_MODULE)).ToLocalChecked());
+    auto name_str = v8::Local<v8::String>::Cast(
+      desc->Get(context, store->v8_string(V8_S_NAME)).ToLocalChecked());
+    auto kind_str = v8::Local<v8::String>::Cast(
+      desc->Get(context, store->v8_string(V8_S_KIND)).ToLocalChecked());
+
+    auto type = wasm_externtype_new_from_v8_kind(store, kind_str);
+    auto module = wasm_byte_vec_new_from_v8_string(module_str);
+    auto name = wasm_byte_vec_new_from_v8_string(name_str);
+    imports.data[i] = wasm_importtype_new(module, name, type);
+  }
+
+  return imports;
+*/
+}
+
+wasm_exporttype_vec_t wasm_module_exports(wasm_module_t* module) {
+  return module->exports.borrow();
+/* OBSOLETE?
+  auto store = module->store();
+  auto isolate = store->isolate();
+  auto context = store->context();
+  v8::HandleScope handle_scope(isolate);
+
+  v8::Local<v8::Value> args[] = { module->v8_object() };
+  auto result = store->v8_function(V8_F_EXPORTS)->Call(
+    context, v8::Undefined(isolate), 1, args);
+  if (result.IsEmpty()) return wasm_exporttype_vec_empty();
+  auto array = v8::Local<v8::Array>::Cast(result.ToLocalChecked());
+  size_t size = array->Length();
+
+  wasm_exporttype_vec_t exports = wasm_exporttype_vec_new_uninitialized(size);
+  for (size_t i = 0; i < size; ++i) {
+    auto desc = v8::Local<v8::Object>::Cast(array->Get(i));
+    auto name_str = v8::Local<v8::String>::Cast(
+      desc->Get(context, store->v8_string(V8_S_NAME)).ToLocalChecked());
+    auto kind_str = v8::Local<v8::String>::Cast(
+      desc->Get(context, store->v8_string(V8_S_KIND)).ToLocalChecked());
+
+    auto type = wasm_externtype_new_from_v8_kind(store, kind_str);
+    auto name = wasm_byte_vec_new_from_v8_string(name_str);
+    exports.data[i] = wasm_exporttype_new(name, type);
+  }
+
+  return exports;
+*/
+}
+
+own wasm_byte_vec_t wasm_module_serialize(wasm_module_t*) {
+  UNIMPLEMENTED("wasm_module_serialize");
+}
+
+own wasm_module_t* wasm_module_deserialize(wasm_byte_vec_t) {
+  UNIMPLEMENTED("wasm_module_deserialize");
+}
+
+
+// Host Objects
+
+struct wasm_hostobj_t : wasm_ref_t {
+  using wasm_ref_t::wasm_ref_t;
+};
+
+WASM_DEFINE_REF(hostobj)
+
+own wasm_hostobj_t* wasm_hostobj_new(wasm_store_t* store) {
+  auto isolate = store->isolate();
+  v8::HandleScope handle_scope(isolate);
+
+  auto obj = v8::Object::New(isolate);
+  return new wasm_hostobj_t(store, obj);
+}
+
+
+// Function Instances
+
+struct wasm_func_t : wasm_ref_t {
+  owned<wasm_functype_t*> type;
+  wasm_func_callback_t callback;
+
+  wasm_func_t(wasm_store_t* store, v8::Local<v8::Function> obj, wasm_functype_t* type, wasm_func_callback_t callback = nullptr) :
+    wasm_ref_t(store, obj), type(type), callback(callback) {}
+
+  v8::Local<v8::Function> v8_function() const {
+    return v8::Local<v8::Function>::Cast(v8_object());
+  }
+};
+
+WASM_DEFINE_REF(func)
+
+
+void wasm_callback(const v8::FunctionCallbackInfo<v8::Value>& info) {
+  auto data = v8::Local<v8::Object>::Cast(info.Data());
+  auto func = reinterpret_cast<wasm_func_t*>(
+    data->GetAlignedPointerFromInternalField(0));
+  auto store = func->store();
+  auto isolate = store->isolate();
+  v8::HandleScope handle_scope(isolate);
+
+  auto context = store->context();
+  auto type = func->type.borrow();
+  auto type_params = type->params.borrow();
+  auto type_results = type->results.borrow();
+
+  assert(type_params.size == info.Length());
+
+  owned<wasm_val_vec_t> own_args = wasm_val_vec_new_uninitialized(type_params.size);
+  auto args = own_args.borrow();
+  for (size_t i = 0; i < type_params.size; ++i) {
+    args.data[i] = wasm_v8_to_val(store, info[i], type_params.data[i]);
+  }
+
+  owned<wasm_val_vec_t> own_results = func->callback(args);
+  auto results = own_results.borrow();
+
+  assert(type_results.size == results.size);
+
+  auto ret = info.GetReturnValue();
+  if (type_results.size == 0) {
+    ret.SetUndefined();
+  } else if (type_results.size == 1) {
+    assert(results.data[0].kind == wasm_valtype_kind(type_results.data[0]));
+    ret.Set(wasm_val_to_v8(store, results.data[0]));
+  } else {
+    UNIMPLEMENTED("multiple results");
+  }
+}
+
+
+own wasm_func_t* wasm_func_new(wasm_store_t* store, wasm_functype_t* type, wasm_func_callback_t callback) {
+  auto isolate = store->isolate();
+  v8::HandleScope handle_scope(isolate);
+  auto context = store->context();
+
+  // TODO(lowlevel): use V8 Foreign value
+  auto data_template = store->callback_data_template();
+  auto maybe_data = data_template->NewInstance(context);
+  if (maybe_data.IsEmpty()) return nullptr;
+  auto data = maybe_data.ToLocalChecked();
+
+  auto function_template = v8::FunctionTemplate::New(isolate, &wasm_callback, data);
+  auto maybe_function = function_template->GetFunction(context);
+  if (maybe_function.IsEmpty()) return nullptr;
+  auto function = maybe_function.ToLocalChecked();
+
+  auto type_clone = wasm_functype_clone(type);
+  if (type_clone == nullptr) return nullptr;
+  auto func = new wasm_func_t(store, function, type_clone, callback);
+  data->SetAlignedPointerInInternalField(0, func);
+  return func;
+}
+
+wasm_func_t *wasm_func_new_with_env(wasm_store_t*, wasm_functype_t* type, wasm_func_callback_with_env_t callback, wasm_ref_t *env) {
+  UNIMPLEMENTED("wasm_func_new_with_env");
+}
+
+own wasm_functype_t* wasm_func_type(wasm_func_t* func) {
+  return wasm_functype_clone(func->type.borrow());
+}
+
+own wasm_val_vec_t wasm_func_call(wasm_func_t* func, wasm_val_vec_t args) {
+  auto store = func->store();
+  auto isolate = store->isolate();
+  v8::HandleScope handle_scope(isolate);
+
+  auto context = store->context();
+  auto type = func->type.borrow();
+  auto type_params = type->params.borrow();
+  auto type_results = type->results.borrow();
+
+  assert(type_params.size == args.size);
+
+  auto v8_args = new v8::Local<v8::Value>[type_params.size];
+  for (size_t i = 0; i < type_params.size; ++i) {
+    assert(args.data[i].kind == wasm_valtype_kind(type_params.data[i]));
+    v8_args[i] = wasm_val_to_v8(store, args.data[i]);
+  }
+
+  auto maybe_result =
+    func->v8_function()->Call(context, v8::Undefined(isolate), args.size, v8_args);
+  if (maybe_result.IsEmpty()) return wasm_val_vec_empty();
+  auto result = maybe_result.ToLocalChecked();
+
+  if (type_results.size == 0) {
+    assert(result->IsUndefined());
+    return wasm_val_vec_empty();
+  } else if (type_results.size == 1) {
+    assert(!result->IsUndefined());
+    auto val = wasm_v8_to_val(store, result, type_results.data[0]);
+    return wasm_val_vec_new(1, &val);
+  } else {
+    UNIMPLEMENTED("multiple results");
+  }
+}
+
+
+// Global Instances
+
+struct wasm_global_t : wasm_ref_t {
+  owned<wasm_globaltype_t*> type;
+
+  wasm_global_t(wasm_store_t* store, v8::Local<v8::Object> obj, own wasm_globaltype_t* type) :
+    wasm_ref_t(store, obj), type(type) {}
+};
+
+WASM_DEFINE_REF(global)
+
+own wasm_globaltype_t* wasm_global_type(wasm_global_t* global) {
+  return wasm_globaltype_clone(global->type.borrow());
+}
+
+wasm_global_t* wasm_global_new(wasm_store_t* store, wasm_globaltype_t* type, wasm_val_t val) {
+  auto isolate = store->isolate();
+  v8::HandleScope handle_scope(isolate);
+  auto context = store->context();
+
+  assert(wasm_valtype_kind(wasm_globaltype_content(type)) == val.kind);
+
+  // TODO(wasm+): remove
+  if (store->v8_function(V8_F_GLOBAL).IsEmpty()) {
+    UNIMPLEMENTED("wasm_global_new");
+  }
+
+  v8::Local<v8::Value> args[] = {
+    wasm_globaltype_to_v8(store, type),
+    wasm_val_to_v8(store, val)
+  };
+  auto maybe_obj =
+    store->v8_function(V8_F_GLOBAL)->NewInstance(context, 2, args);
+  if (maybe_obj.IsEmpty()) return nullptr;
+  auto obj = maybe_obj.ToLocalChecked();
+
+  auto type_clone = wasm_globaltype_clone(type);
+  if (type_clone == nullptr) return nullptr;
+  return new wasm_global_t(store, obj, type_clone);
+}
+
+own wasm_val_t wasm_global_get(wasm_global_t* global) {
+  auto store = global->store();
+  auto isolate = store->isolate();
+  v8::HandleScope handle_scope(isolate);
+  auto context = store->context();
+
+  // TODO(wasm+): remove
+  if (store->v8_function(V8_F_GLOBAL_GET).IsEmpty()) {
+    UNIMPLEMENTED("wasm_global_get");
+  }
+
+  auto maybe_val =
+    store->v8_function(V8_F_GLOBAL_GET)->Call(context, global->v8_object(), 0, nullptr);
+  if (maybe_val.IsEmpty()) return wasm_null_val();
+  auto val = maybe_val.ToLocalChecked();
+
+  auto content_type = wasm_globaltype_content(global->type.borrow());
+  return wasm_v8_to_val(store, val, content_type);
+}
+
+void wasm_global_set(wasm_global_t* global, wasm_val_t val) {
+  auto store = global->store();
+  auto isolate = store->isolate();
+  v8::HandleScope handle_scope(isolate);
+  auto context = store->context();
+
+  auto content_type = wasm_globaltype_content(global->type.borrow());
+  assert(val.kind == wasm_valtype_kind(content_type));
+
+  // TODO(wasm+): remove
+  if (store->v8_function(V8_F_GLOBAL_SET).IsEmpty()) {
+    UNIMPLEMENTED("wasm_global_set");
+  }
+
+  v8::Local<v8::Value> args[] = { wasm_val_to_v8(store, val) };
+  store->v8_function(V8_F_GLOBAL_SET)->Call(context, global->v8_object(), 1, args);
+}
+
+
+// Table Instances
+
+struct wasm_table_t : wasm_ref_t {
+  owned<wasm_tabletype_t*> type;
+
+  wasm_table_t(wasm_store_t* store, v8::Local<v8::Object> obj, own wasm_tabletype_t* type) :
+    wasm_ref_t(store, obj), type(type) {}
+};
+
+WASM_DEFINE_REF(table)
+
+wasm_table_t* wasm_table_new(wasm_store_t* store, wasm_tabletype_t* type, wasm_ref_t*) {
+  auto isolate = store->isolate();
+  v8::HandleScope handle_scope(isolate);
+  auto context = store->context();
+
+  // TODO(wasm+): handle reference initialiser
+  v8::Local<v8::Value> args[] = { wasm_tabletype_to_v8(store, type) };
+  auto maybe_obj =
+    store->v8_function(V8_F_TABLE)->NewInstance(context, 1, args);
+  if (maybe_obj.IsEmpty()) return nullptr;
+  auto obj = maybe_obj.ToLocalChecked();
+
+  auto type_clone = wasm_tabletype_clone(type);
+  if (type_clone == nullptr) return nullptr;
+  return new wasm_table_t(store, obj, type_clone);
+}
+
+own wasm_tabletype_t* wasm_table_type(wasm_table_t* table) {
+  // TODO: query and update min
+  return wasm_tabletype_clone(table->type.borrow());
+}
+
+
+own wasm_ref_t* wasm_table_get(wasm_table_t*, wasm_table_size_t index) {
+  UNIMPLEMENTED("wasm_table_get");
+}
+
+void wasm_table_set(wasm_table_t*, wasm_table_size_t index, wasm_ref_t*) {
+  UNIMPLEMENTED("wasm_table_set");
+}
+
+wasm_table_size_t wasm_table_size(wasm_table_t*) {
+  UNIMPLEMENTED("wasm_table_size");
+}
+
+wasm_table_size_t wasm_table_grow(wasm_table_t*, wasm_table_size_t delta) {
+  UNIMPLEMENTED("wasm_table_grow");
+}
+
+
+// Memory Instances
+
+struct wasm_memory_t : wasm_ref_t {
+  owned<wasm_memtype_t*> type;
+
+  wasm_memory_t(wasm_store_t* store, v8::Local<v8::Object> obj, own wasm_memtype_t* type) :
+    wasm_ref_t(store, obj), type(type) {}
+};
+
+WASM_DEFINE_REF(memory)
+
+wasm_memory_t* wasm_memory_new(wasm_store_t* store, wasm_memtype_t* type) {
+  auto isolate = store->isolate();
+  v8::HandleScope handle_scope(isolate);
+  auto context = store->context();
+
+  v8::Local<v8::Value> args[] = { wasm_memtype_to_v8(store, type) };
+  auto maybe_obj =
+    store->v8_function(V8_F_MEMORY)->NewInstance(context, 1, args);
+  if (maybe_obj.IsEmpty()) return nullptr;
+  auto obj = maybe_obj.ToLocalChecked();
+
+  auto type_clone = wasm_memtype_clone(type);
+  if (type_clone == nullptr) return nullptr;
+  return new wasm_memory_t(store, obj, type_clone);
+}
+
+own wasm_memtype_t* wasm_memory_type(wasm_memory_t* memory) {
+  // TODO: query and update min
+  return wasm_memtype_clone(memory->type.borrow());
+}
+
+wasm_byte_t* wasm_memory_data(wasm_memory_t*) {
+  UNIMPLEMENTED("wasm_memory_data");
+}
+
+size_t wasm_memory_data_size(wasm_memory_t*) {
+  UNIMPLEMENTED("wasm_memory_data_size");
+}
+
+wasm_memory_pages_t wasm_memory_size(wasm_memory_t*) {
+  UNIMPLEMENTED("wasm_memory_size");
+}
+
+wasm_memory_pages_t wasm_memory_grow(wasm_memory_t*, wasm_memory_pages_t delta) {
+  UNIMPLEMENTED("wasm_memory_grow");
+}
+
+
+// Externals
+
+WASM_DEFINE_VEC(extern, )
+
+extern "C++"
+void delete_own(own wasm_extern_t ex) {
+  switch (ex.kind) {
+    case WASM_EXTERN_FUNC: return wasm_func_delete(ex.func);
+    case WASM_EXTERN_GLOBAL: return wasm_global_delete(ex.global);
+    case WASM_EXTERN_TABLE: return wasm_table_delete(ex.table);
+    case WASM_EXTERN_MEMORY: return wasm_memory_delete(ex.memory);
+  }
+}
+
+void wasm_extern_delete(own wasm_extern_t ex) {
+  delete_own(ex);
+}
+
+own wasm_extern_t wasm_extern_clone(wasm_extern_t ex) {
+  switch (ex.kind) {
+    case WASM_EXTERN_FUNC: return wasm_extern_func(wasm_func_clone(ex.func));
+    case WASM_EXTERN_GLOBAL: return wasm_extern_global(wasm_global_clone(ex.global));
+    case WASM_EXTERN_TABLE: return wasm_extern_table(wasm_table_clone(ex.table));
+    case WASM_EXTERN_MEMORY: return wasm_extern_memory(wasm_memory_clone(ex.memory));
+  }
+}
+
+extern "C++"
+v8::Local<v8::Object> wasm_extern_to_v8(wasm_extern_t ex) {
+  switch (ex.kind) {
+    case WASM_EXTERN_FUNC: return ex.func->v8_object();
+    case WASM_EXTERN_GLOBAL: return ex.global->v8_object();
+    case WASM_EXTERN_TABLE: return ex.table->v8_object();
+    case WASM_EXTERN_MEMORY: return ex.memory->v8_object();
+  }
+}
+
+
+// Module Instances
+
+struct wasm_instance_t : wasm_ref_t {
+  owned<wasm_extern_vec_t> exports;
+
+  wasm_instance_t(wasm_store_t* store, v8::Local<v8::Object> obj, own wasm_extern_vec_t exports) :
+    wasm_ref_t(store, obj), exports(exports) {}
+};
+
+WASM_DEFINE_REF(instance)
+
+own wasm_instance_t* wasm_instance_new(wasm_store_t* store, wasm_module_t* module, wasm_extern_vec_t imports) {
+  auto isolate = store->isolate();
+  auto context = store->context();
+  v8::HandleScope handle_scope(isolate);
+
+  v8::Local<v8::Value> imports_args[] = { module->v8_object() };
+  auto imports_result = store->v8_function(V8_F_IMPORTS)->Call(
+    context, v8::Undefined(isolate), 1, imports_args);
+  if (imports_result.IsEmpty()) return nullptr;
+  auto imports_array = v8::Local<v8::Array>::Cast(imports_result.ToLocalChecked());
+  size_t imports_size = imports_array->Length();
+
+  auto imports_obj = v8::Object::New(isolate);
+  for (size_t i = 0; i < imports_size; ++i) {
+    auto desc = v8::Local<v8::Object>::Cast(imports_array->Get(i));
+    auto module_str = v8::Local<v8::String>::Cast(
+      desc->Get(context, store->v8_string(V8_S_MODULE)).ToLocalChecked());
+    auto name_str = v8::Local<v8::String>::Cast(
+      desc->Get(context, store->v8_string(V8_S_NAME)).ToLocalChecked());
+
+    v8::Local<v8::Object> module_obj;
+    if (imports_obj->HasOwnProperty(context, module_str).ToChecked()) {
+      module_obj = v8::Local<v8::Object>::Cast(
+        imports_obj->Get(context, module_str).ToLocalChecked());
+    } else {
+      module_obj = v8::Object::New(isolate);
+      imports_obj->DefineOwnProperty(context, module_str, module_obj);
+    }
+
+    module_obj->DefineOwnProperty(context, name_str, wasm_extern_to_v8(imports.data[i]));
+  }
+
+  v8::Local<v8::Value> instantiate_args[] = {module->v8_object(), imports_obj};
+  auto instance_obj =
+    store->v8_function(V8_F_INSTANCE)->NewInstance(context, 2, instantiate_args).ToLocalChecked();
+  auto exports_obj = v8::Local<v8::Object>::Cast(
+    instance_obj->Get(context, store->v8_string(V8_S_EXPORTS)).ToLocalChecked());
+  assert(!exports_obj.IsEmpty() && exports_obj->IsObject());
+
+  auto export_types = module->exports.borrow();
+  owned<wasm_extern_vec_t> own_exports =
+    wasm_extern_vec_new_uninitialized(export_types.size);
+  auto exports = own_exports.borrow();
+  for (size_t i = 0; i < export_types.size; ++i) {
+    auto name = export_types.data[i]->name.borrow();
+    auto maybe_name_obj = v8::String::NewFromUtf8(isolate, name.data,
+      v8::NewStringType::kNormal, name.size);
+    if (maybe_name_obj.IsEmpty()) return nullptr;
+    auto name_obj = maybe_name_obj.ToLocalChecked();
+    auto obj = v8::Local<v8::Function>::Cast(
+      exports_obj->Get(context, name_obj).ToLocalChecked());
+
+    auto type = export_types.data[i]->type.borrow();
+    switch (wasm_externtype_kind(type)) {
+      case WASM_EXTERN_FUNC: {
+        auto func_obj = v8::Local<v8::Function>::Cast(obj);
+        auto functype = wasm_functype_clone(wasm_externtype_as_functype(type));
+        if (functype == nullptr) return nullptr;
+        auto func = new wasm_func_t(store, func_obj, functype);
+        exports.data[i] = wasm_extern_func(func);
+      } break;
+      case WASM_EXTERN_GLOBAL: {
+        auto globaltype = wasm_globaltype_clone(wasm_externtype_as_globaltype(type));
+        if (globaltype == nullptr) return nullptr;
+        auto global = new wasm_global_t(store, obj, globaltype);
+        exports.data[i] = wasm_extern_global(global);
+      } break;
+      case WASM_EXTERN_TABLE: {
+        auto tabletype = wasm_tabletype_clone(wasm_externtype_as_tabletype(type));
+        if (tabletype == nullptr) return nullptr;
+        auto table = new wasm_table_t(store, obj, tabletype);
+        exports.data[i] = wasm_extern_table(table);
+      } break;
+      case WASM_EXTERN_MEMORY: {
+        auto memtype = wasm_memtype_clone(wasm_externtype_as_memtype(type));
+        if (memtype == nullptr) return nullptr;
+        auto memory = new wasm_memory_t(store, obj, memtype);
+        exports.data[i] = wasm_extern_memory(memory);
+      } break;
+    }
+  }
+
+  return new wasm_instance_t(store, instance_obj, exports);
+}
+
+own wasm_extern_t wasm_instance_export(wasm_instance_t* instance, size_t index) {
+  auto exports = instance->exports.borrow();
+  if (index >= exports.size) return wasm_extern_func(nullptr);
+  return exports.data[index];
+}
+
+own wasm_extern_vec_t wasm_instance_exports(wasm_instance_t* instance) {
+  return wasm_extern_vec_clone(instance->exports.borrow());
+}
+
+}  // extern "C"

--- a/src/wasm-c.cc
+++ b/src/wasm-c.cc
@@ -16,15 +16,15 @@ template<class T>
 struct borrowed {
   own<T> it;
   borrowed(T x) : it(x) {}
-  borrowed(borrowed<T>&& that) : it(std::move(that)) {}
+  borrowed(borrowed<T>&& that) : it(std::move(that.it)) {}
   ~borrowed() { it.release(); }
 };
 
 template<class T>
 struct borrowed_vec {
   vec<T> it;
-  borrowed_vec(vec<T>&& v) : it(v.release()) {}
-  borrowed_vec(borrowed_vec<T>&& that) : it(std::move(that)) {}
+  borrowed_vec(vec<T>&& v) : it(std::move(v)) {}
+  borrowed_vec(borrowed_vec<T>&& that) : it(std::move(that.it)) {}
   ~borrowed_vec() { it.release(); }
 };
 
@@ -62,13 +62,26 @@ struct borrowed_vec {
 
 #define WASM_DEFINE_VEC_BASE(name, ptr_or_none) \
   extern "C++" inline auto hide(name ptr_or_none* v) -> wasm_##name##_t ptr_or_none* { \
+    static_assert(sizeof(wasm_##name##_t ptr_or_none) == sizeof(name ptr_or_none), "C/C++ incompatibility"); \
     return reinterpret_cast<wasm_##name##_t ptr_or_none*>(v); \
   } \
+  extern "C++" inline auto hide(name ptr_or_none const* v) -> wasm_##name##_t ptr_or_none const* { \
+    static_assert(sizeof(wasm_##name##_t ptr_or_none) == sizeof(name ptr_or_none), "C/C++ incompatibility"); \
+    return reinterpret_cast<wasm_##name##_t ptr_or_none const*>(v); \
+  } \
   extern "C++" inline auto reveal(wasm_##name##_t ptr_or_none* v) -> name ptr_or_none* { \
+    static_assert(sizeof(wasm_##name##_t ptr_or_none) == sizeof(name ptr_or_none), "C/C++ incompatibility"); \
     return reinterpret_cast<name ptr_or_none*>(v); \
+  } \
+  extern "C++" inline auto reveal(wasm_##name##_t ptr_or_none const* v) -> name ptr_or_none const* { \
+    static_assert(sizeof(wasm_##name##_t ptr_or_none) == sizeof(name ptr_or_none), "C/C++ incompatibility"); \
+    return reinterpret_cast<name ptr_or_none const*>(v); \
   } \
   extern "C++" inline auto get(wasm::vec<name ptr_or_none>& v) -> wasm_##name##_vec_t { \
     return wasm_##name##_vec(v.size(), hide(v.get())); \
+  } \
+  extern "C++" inline auto get(const wasm::vec<name ptr_or_none>& v) -> const wasm_##name##_vec_t { \
+    return wasm_##name##_vec(v.size(), const_cast<wasm_##name##_t ptr_or_none*>(hide(v.get()))); \
   } \
   extern "C++" inline auto release(wasm::vec<name ptr_or_none>&& v) -> wasm_##name##_vec_t { \
     return wasm_##name##_vec(v.size(), hide(v.release())); \
@@ -76,7 +89,7 @@ struct borrowed_vec {
   extern "C++" inline auto adopt(wasm_##name##_vec_t v) -> wasm::vec<name ptr_or_none> { \
     return wasm::vec<name ptr_or_none>::adopt(v.size, reveal(v.data)); \
   } \
-  extern "C++" inline auto borrow_vec(wasm_##name##_vec_t v) -> borrowed_vec<name ptr_or_none> { \
+  extern "C++" inline auto borrow(wasm_##name##_vec_t v) -> borrowed_vec<name ptr_or_none> { \
     return borrowed_vec<name ptr_or_none>(wasm::vec<name ptr_or_none>::adopt(v.size, reveal(v.data))); \
   } \
   \
@@ -120,7 +133,7 @@ struct borrowed_vec {
   wasm_##name##_vec_t wasm_##name##_vec_clone(wasm_##name##_vec_t v) { \
     auto v2 = wasm::vec<name ptr_or_none>::make_uninitialized(v.size); \
     for (size_t i = 0; i < v2.size(); ++i) { \
-      v2[i] = v.data[i]->clone(); \
+      v2[i] = adopt(wasm_##name##_clone(v.data[i])); \
     } \
     return release(std::move(v2)); \
   } \
@@ -128,11 +141,16 @@ struct borrowed_vec {
   void wasm_##name##_vec_delete(wasm_##name##_vec_t v) { \
     if (v.data) { \
       for (size_t i = 0; i < v.size; ++i) { \
-        if (v.data[i]) wasm_##name##_delete(v.data[i]); \
+        if (!is_empty(v.data[i])) wasm_##name##_delete(v.data[i]); \
       } \
-      delete[] v.data; \
+      delete[] reveal(v.data); \
     } \
   }
+
+extern "C++" {
+template<class T>
+inline auto is_empty(T* p) -> bool { return !p; }
+}
 
 
 // Byte vectors
@@ -384,62 +402,6 @@ wasm_externtype_t* wasm_exporttype_type(wasm_exporttype_t* et) {
 ///////////////////////////////////////////////////////////////////////////////
 // Runtime Values
 
-// Values
-
-WASM_DEFINE_VEC(val, )
-
-void wasm_val_delete(wasm_val_t val) {
-  delete_own(val);
-}
-
-own wasm_val_t wasm_val_clone(wasm_val_t val) {
-  if (wasm_valkind_is_refkind(val.kind)) {
-    val.ref = wasm_ref_clone(val.ref);
-  }
-  return val;
-}
-
-extern "C++" inline auto hide(wasm::val v) -> wasm_val_t {
-  wasm_val_t v2 = { hide(v.kind()) };
-  switch (v.kind()) {
-    case I32: v2.i32 = v.i32(); break;
-    case I64: v2.i64 = v.i64(); break;
-    case F32: v2.f32 = v.f32(); break;
-    case F64: v2.f64 = v.f64(); break;
-    case ANYREF:
-    case FUNCREF: v2.ref = v.release(); break;
-    default: assert(false);
-  }
-  return v2;
-}
-
-extern "C++" inline auto reveal(wasm_val_t v) -> wasm::val {
-  switch (reveal(v.kind)) {
-    case I32: return val(v.i32);
-    case I64: return val(v.i64);
-    case F32: return val(v.f32);
-    case F64: return val(v.f64);
-    case ANYREF:
-    case FUNCREF: return val(adopt(v.ref));
-    default: assert(false);
-  }
-}
-
-extern "C++" inline auto get(val v) -> wasm_##name##_t* {
-
-  return hide(x.get());
-  } \
-  extern "C++" inline auto release(own<wasm::name*>&& x) -> wasm_##name##_t* { \
-    return hide(x.release()); \
-  } \
-  extern "C++" inline auto adopt(wasm_##name##_t* x) -> own<wasm::name*> { \
-    return make_own(x); \
-  } \
-  extern "C++" inline auto borrow(wasm_##name##_t* x) -> borrowed<name*> { \
-    return borrowed<name*>(x); \
-  }
-
-
 // References
 
 WASM_DEFINE_OWN(ref)
@@ -476,593 +438,331 @@ wasm_ref_t* wasm_ref_clone(wasm_ref_t* r) {
   }
 
 
+// Values
+
+extern "C++" {
+
+inline auto is_empty(wasm_val_t v) -> bool {
+ return !is_ref(reveal(v.kind)) || !v.ref;
+}
+
+inline auto hide(wasm::val v) -> wasm_val_t {
+  wasm_val_t v2 = { hide(v.kind()) };
+  switch (v.kind()) {
+    case I32: v2.i32 = v.i32(); break;
+    case I64: v2.i64 = v.i64(); break;
+    case F32: v2.f32 = v.f32(); break;
+    case F64: v2.f64 = v.f64(); break;
+    case ANYREF:
+    case FUNCREF: v2.ref = hide(v.ref()); break;
+    default: assert(false);
+  }
+  return v2;
+}
+
+inline auto release(wasm::val v) -> wasm_val_t {
+  wasm_val_t v2 = { hide(v.kind()) };
+  switch (v.kind()) {
+    case I32: v2.i32 = v.i32(); break;
+    case I64: v2.i64 = v.i64(); break;
+    case F32: v2.f32 = v.f32(); break;
+    case F64: v2.f64 = v.f64(); break;
+    case ANYREF:
+    case FUNCREF: v2.ref = release(v.release_ref()); break;
+    default: assert(false);
+  }
+  return v2;
+}
+
+inline auto adopt(wasm_val_t v) -> wasm::val {
+  switch (reveal(v.kind)) {
+    case I32: return val(v.i32);
+    case I64: return val(v.i64);
+    case F32: return val(v.f32);
+    case F64: return val(v.f64);
+    case ANYREF:
+    case FUNCREF: return val(adopt(v.ref));
+    default: assert(false);
+  }
+}
+
+struct borrowed_val {
+  val it;
+  borrowed_val(val&& v) : it(std::move(v)) {}
+  borrowed_val(borrowed_val&& that) : it(std::move(that.it)) {}
+  ~borrowed_val() { it.release_ref(); }
+};
+
+inline auto borrow(wasm_val_t v) -> borrowed_val {
+  val v2;
+  switch (reveal(v.kind)) {
+    case I32: v2 = val(v.i32); break;
+    case I64: v2 = val(v.i64); break;
+    case F32: v2 = val(v.f32); break;
+    case F64: v2 = val(v.f64); break;
+    case ANYREF:
+    case FUNCREF: v2 = val(adopt(v.ref)); break;
+    default: assert(false);
+  }
+  return borrowed_val(std::move(v2));
+}
+
+}  // extern "C++"
+
+WASM_DEFINE_VEC(val, )
+
+
+void wasm_val_delete(wasm_val_t v) {
+  if (is_ref(reveal(v.kind))) adopt(v.ref);
+}
+
+wasm_val_t wasm_val_clone(wasm_val_t v) {
+  wasm_val_t v2 = v;
+  if (is_ref(reveal(v.kind))) {
+    v2.ref = release(v.ref->clone());
+  }
+  return v2;
+}
+
+
 ///////////////////////////////////////////////////////////////////////////////
 // Runtime Objects
 
 // Modules
 
-struct wasm_module_t : wasm_ref_t {
-  owned<wasm_importtype_vec_t> imports;
-  owned<wasm_exporttype_vec_t> exports;
-
-  wasm_module_t(wasm_store_t* store, v8::Local<v8::Object> obj,
-    own wasm_importtype_vec_t imports, own wasm_exporttype_vec_t exports) :
-    wasm_ref_t(store, obj), imports(imports), exports(exports) {}
-};
 
 WASM_DEFINE_REF(module)
 
-own wasm_module_t* wasm_module_new(wasm_store_t* store, wasm_byte_vec_t binary) {
-  auto isolate = store->isolate();
-  auto context = store->context();
-  v8::HandleScope handle_scope(isolate);
-
-  auto array_buffer = v8::ArrayBuffer::New(isolate, binary.data, binary.size);
-
-  v8::Local<v8::Value> args[] = {array_buffer};
-  auto maybe_obj =
-    store->v8_function(V8_F_MODULE)->NewInstance(context, 1, args);
-  if (maybe_obj.IsEmpty()) return nullptr;
-  auto obj = maybe_obj.ToLocalChecked();
-
-  // TODO(wasm+): use JS API once available?
-  auto imports_exports = wasm::bin::imports_exports(binary);
-  // TODO store->cache_set(module_obj, module);
-  return new wasm_module_t(store, obj, std::get<0>(imports_exports), std::get<1>(imports_exports));
+bool wasm_module_validate(wasm_store_t* store, wasm_byte_vec_t binary) {
+  auto store_ = borrow(store);
+  auto binary_ = borrow(binary);
+  return module::validate(store_.it, binary_.it);
 }
 
-bool wasm_module_validate(wasm_store_t* store, wasm_byte_vec_t binary) {
-  v8::Isolate* isolate = store->isolate();
-  v8::HandleScope handle_scope(isolate);
-
-  auto array_buffer = v8::ArrayBuffer::New(isolate, binary.data, binary.size);
-
-  v8::Local<v8::Value> args[] = {array_buffer};
-  auto result = store->v8_function(V8_F_VALIDATE)->Call(
-    store->context(), v8::Undefined(isolate), 1, args);
-  if (result.IsEmpty()) return false;
-
-  return result.ToLocalChecked()->IsTrue();
+wasm_module_t* wasm_module_new(wasm_store_t* store, wasm_byte_vec_t binary) {
+  auto store_ = borrow(store);
+  auto binary_ = borrow(binary);
+  return release(module::make(store_.it, binary_.it));
 }
 
 
 wasm_importtype_vec_t wasm_module_imports(wasm_module_t* module) {
-  return module->imports.borrow();
-/* OBSOLETE?
-  auto store = module->store();
-  auto isolate = store->isolate();
-  auto context = store->context();
-  v8::HandleScope handle_scope(isolate);
-
-  v8::Local<v8::Value> args[] = { module->v8_object() };
-  auto result = store->v8_function(V8_F_IMPORTS)->Call(
-    context, v8::Undefined(isolate), 1, args);
-  if (result.IsEmpty()) return wasm_importtype_vec_empty();
-  auto array = v8::Local<v8::Array>::Cast(result.ToLocalChecked());
-  size_t size = array->Length();
-
-  wasm_importtype_vec_t imports = wasm_importtype_vec_new_uninitialized(size);
-  for (size_t i = 0; i < size; ++i) {
-    auto desc = v8::Local<v8::Object>::Cast(array->Get(i));
-    auto module_str = v8::Local<v8::String>::Cast(
-      desc->Get(context, store->v8_string(V8_S_MODULE)).ToLocalChecked());
-    auto name_str = v8::Local<v8::String>::Cast(
-      desc->Get(context, store->v8_string(V8_S_NAME)).ToLocalChecked());
-    auto kind_str = v8::Local<v8::String>::Cast(
-      desc->Get(context, store->v8_string(V8_S_KIND)).ToLocalChecked());
-
-    auto type = wasm_externtype_new_from_v8_kind(store, kind_str);
-    auto module = wasm_byte_vec_new_from_v8_string(module_str);
-    auto name = wasm_byte_vec_new_from_v8_string(name_str);
-    imports.data[i] = wasm_importtype_new(module, name, type);
-  }
-
-  return imports;
-*/
+  return release(reveal(module)->imports());
 }
 
 wasm_exporttype_vec_t wasm_module_exports(wasm_module_t* module) {
-  return module->exports.borrow();
-/* OBSOLETE?
-  auto store = module->store();
-  auto isolate = store->isolate();
-  auto context = store->context();
-  v8::HandleScope handle_scope(isolate);
-
-  v8::Local<v8::Value> args[] = { module->v8_object() };
-  auto result = store->v8_function(V8_F_EXPORTS)->Call(
-    context, v8::Undefined(isolate), 1, args);
-  if (result.IsEmpty()) return wasm_exporttype_vec_empty();
-  auto array = v8::Local<v8::Array>::Cast(result.ToLocalChecked());
-  size_t size = array->Length();
-
-  wasm_exporttype_vec_t exports = wasm_exporttype_vec_new_uninitialized(size);
-  for (size_t i = 0; i < size; ++i) {
-    auto desc = v8::Local<v8::Object>::Cast(array->Get(i));
-    auto name_str = v8::Local<v8::String>::Cast(
-      desc->Get(context, store->v8_string(V8_S_NAME)).ToLocalChecked());
-    auto kind_str = v8::Local<v8::String>::Cast(
-      desc->Get(context, store->v8_string(V8_S_KIND)).ToLocalChecked());
-
-    auto type = wasm_externtype_new_from_v8_kind(store, kind_str);
-    auto name = wasm_byte_vec_new_from_v8_string(name_str);
-    exports.data[i] = wasm_exporttype_new(name, type);
-  }
-
-  return exports;
-*/
+  return release(reveal(module)->exports());
 }
 
-own wasm_byte_vec_t wasm_module_serialize(wasm_module_t*) {
-  UNIMPLEMENTED("wasm_module_serialize");
+wasm_byte_vec_t wasm_module_serialize(wasm_module_t* module) {
+  return release(reveal(module)->serialize());
 }
 
-own wasm_module_t* wasm_module_deserialize(wasm_byte_vec_t) {
-  UNIMPLEMENTED("wasm_module_deserialize");
+wasm_module_t* wasm_module_deserialize(wasm_byte_vec_t binary) {
+  auto binary_ = borrow(binary);
+  return release(module::deserialize(binary_.it));
 }
 
 
 // Host Objects
 
-struct wasm_hostobj_t : wasm_ref_t {
-  using wasm_ref_t::wasm_ref_t;
-};
-
 WASM_DEFINE_REF(hostobj)
 
-own wasm_hostobj_t* wasm_hostobj_new(wasm_store_t* store) {
-  auto isolate = store->isolate();
-  v8::HandleScope handle_scope(isolate);
-
-  auto obj = v8::Object::New(isolate);
-  return new wasm_hostobj_t(store, obj);
+wasm_hostobj_t* wasm_hostobj_new(wasm_store_t* store) {
+  auto store_ = borrow(store);
+  return release(hostobj::make(store_.it));
 }
 
 
 // Function Instances
 
-struct wasm_func_t : wasm_ref_t {
-  owned<wasm_functype_t*> type;
-  wasm_func_callback_t callback;
-
-  wasm_func_t(wasm_store_t* store, v8::Local<v8::Function> obj, wasm_functype_t* type, wasm_func_callback_t callback = nullptr) :
-    wasm_ref_t(store, obj), type(type), callback(callback) {}
-
-  v8::Local<v8::Function> v8_function() const {
-    return v8::Local<v8::Function>::Cast(v8_object());
-  }
-};
-
 WASM_DEFINE_REF(func)
 
+extern "C++" {
 
-void wasm_callback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-  auto data = v8::Local<v8::Object>::Cast(info.Data());
-  auto func = reinterpret_cast<wasm_func_t*>(
-    data->GetAlignedPointerFromInternalField(0));
-  auto store = func->store();
-  auto isolate = store->isolate();
-  v8::HandleScope handle_scope(isolate);
-
-  auto context = store->context();
-  auto type = func->type.borrow();
-  auto type_params = type->params.borrow();
-  auto type_results = type->results.borrow();
-
-  assert(type_params.size == info.Length());
-
-  owned<wasm_val_vec_t> own_args = wasm_val_vec_new_uninitialized(type_params.size);
-  auto args = own_args.borrow();
-  for (size_t i = 0; i < type_params.size; ++i) {
-    args.data[i] = wasm_v8_to_val(store, info[i], type_params.data[i]);
-  }
-
-  owned<wasm_val_vec_t> own_results = func->callback(args);
-  auto results = own_results.borrow();
-
-  assert(type_results.size == results.size);
-
-  auto ret = info.GetReturnValue();
-  if (type_results.size == 0) {
-    ret.SetUndefined();
-  } else if (type_results.size == 1) {
-    assert(results.data[0].kind == wasm_valtype_kind(type_results.data[0]));
-    ret.Set(wasm_val_to_v8(store, results.data[0]));
-  } else {
-    UNIMPLEMENTED("multiple results");
-  }
+vec<val> wasm_callback(void* env, const vec<val>& args) {
+  auto f = reinterpret_cast<wasm_func_callback_t>(env);
+  return adopt(f(get(args)));
 }
 
+using wasm_callback_env =
+  std::tuple<wasm_func_callback_with_env_t, void*, void (*)(void*)>;
 
-own wasm_func_t* wasm_func_new(wasm_store_t* store, wasm_functype_t* type, wasm_func_callback_t callback) {
-  auto isolate = store->isolate();
-  v8::HandleScope handle_scope(isolate);
-  auto context = store->context();
-
-  // TODO(lowlevel): use V8 Foreign value
-  auto data_template = store->callback_data_template();
-  auto maybe_data = data_template->NewInstance(context);
-  if (maybe_data.IsEmpty()) return nullptr;
-  auto data = maybe_data.ToLocalChecked();
-
-  auto function_template = v8::FunctionTemplate::New(isolate, &wasm_callback, data);
-  auto maybe_function = function_template->GetFunction(context);
-  if (maybe_function.IsEmpty()) return nullptr;
-  auto function = maybe_function.ToLocalChecked();
-
-  auto type_clone = wasm_functype_clone(type);
-  if (type_clone == nullptr) return nullptr;
-  auto func = new wasm_func_t(store, function, type_clone, callback);
-  data->SetAlignedPointerInInternalField(0, func);
-  return func;
+vec<val> wasm_callback_with_env(void* env, const vec<val>& args) {
+  auto t = *static_cast<wasm_callback_env*>(env);
+  return adopt(std::get<0>(t)(std::get<1>(t), get(args)));
 }
 
-wasm_func_t *wasm_func_new_with_env(wasm_store_t*, wasm_functype_t* type, wasm_func_callback_with_env_t callback, wasm_ref_t *env) {
-  UNIMPLEMENTED("wasm_func_new_with_env");
+void wasm_callback_env_finalizer(void* env) {
+  auto t = static_cast<wasm_callback_env*>(env);
+  std::get<2>(*t)(std::get<1>(*t));
+  delete t;
 }
 
-own wasm_functype_t* wasm_func_type(wasm_func_t* func) {
-  return wasm_functype_clone(func->type.borrow());
+}  // extern "C++"
+
+wasm_func_t* wasm_func_new(wasm_store_t* store, wasm_functype_t* type, wasm_func_callback_t callback) {
+  auto store_ = borrow(store);
+  auto type_ = borrow(type);
+  return release(func::make(store_.it, type_.it, wasm_callback, reinterpret_cast<void*>(callback)));
 }
 
-own wasm_val_vec_t wasm_func_call(wasm_func_t* func, wasm_val_vec_t args) {
-  auto store = func->store();
-  auto isolate = store->isolate();
-  v8::HandleScope handle_scope(isolate);
+wasm_func_t *wasm_func_new_with_env(wasm_store_t* store, wasm_functype_t* type, wasm_func_callback_with_env_t callback, wasm_ref_t *env, void (*finalizer)(void*)) {
+  auto store_ = borrow(store);
+  auto type_ = borrow(type);
+  auto env2 = new wasm_callback_env(callback, env);
+  return release(func::make(store_.it, type_.it, wasm_callback_with_env, env2));
+}
 
-  auto context = store->context();
-  auto type = func->type.borrow();
-  auto type_params = type->params.borrow();
-  auto type_results = type->results.borrow();
+wasm_functype_t* wasm_func_type(wasm_func_t* func) {
+  return release(func->type());
+}
 
-  assert(type_params.size == args.size);
-
-  auto v8_args = new v8::Local<v8::Value>[type_params.size];
-  for (size_t i = 0; i < type_params.size; ++i) {
-    assert(args.data[i].kind == wasm_valtype_kind(type_params.data[i]));
-    v8_args[i] = wasm_val_to_v8(store, args.data[i]);
-  }
-
-  auto maybe_result =
-    func->v8_function()->Call(context, v8::Undefined(isolate), args.size, v8_args);
-  if (maybe_result.IsEmpty()) return wasm_val_vec_empty();
-  auto result = maybe_result.ToLocalChecked();
-
-  if (type_results.size == 0) {
-    assert(result->IsUndefined());
-    return wasm_val_vec_empty();
-  } else if (type_results.size == 1) {
-    assert(!result->IsUndefined());
-    auto val = wasm_v8_to_val(store, result, type_results.data[0]);
-    return wasm_val_vec_new(1, &val);
-  } else {
-    UNIMPLEMENTED("multiple results");
-  }
+wasm_val_vec_t wasm_func_call(wasm_func_t* func, wasm_val_vec_t args) {
+  auto func_ = borrow(func);
+  auto args_ = borrow(args);
+  return release(func_.it->call(args_.it));
 }
 
 
 // Global Instances
 
-struct wasm_global_t : wasm_ref_t {
-  owned<wasm_globaltype_t*> type;
-
-  wasm_global_t(wasm_store_t* store, v8::Local<v8::Object> obj, own wasm_globaltype_t* type) :
-    wasm_ref_t(store, obj), type(type) {}
-};
-
 WASM_DEFINE_REF(global)
 
-own wasm_globaltype_t* wasm_global_type(wasm_global_t* global) {
-  return wasm_globaltype_clone(global->type.borrow());
-}
-
 wasm_global_t* wasm_global_new(wasm_store_t* store, wasm_globaltype_t* type, wasm_val_t val) {
-  auto isolate = store->isolate();
-  v8::HandleScope handle_scope(isolate);
-  auto context = store->context();
-
-  assert(wasm_valtype_kind(wasm_globaltype_content(type)) == val.kind);
-
-  // TODO(wasm+): remove
-  if (store->v8_function(V8_F_GLOBAL).IsEmpty()) {
-    UNIMPLEMENTED("wasm_global_new");
-  }
-
-  v8::Local<v8::Value> args[] = {
-    wasm_globaltype_to_v8(store, type),
-    wasm_val_to_v8(store, val)
-  };
-  auto maybe_obj =
-    store->v8_function(V8_F_GLOBAL)->NewInstance(context, 2, args);
-  if (maybe_obj.IsEmpty()) return nullptr;
-  auto obj = maybe_obj.ToLocalChecked();
-
-  auto type_clone = wasm_globaltype_clone(type);
-  if (type_clone == nullptr) return nullptr;
-  return new wasm_global_t(store, obj, type_clone);
+  auto store_ = borrow(store);
+  auto type_ = borrow(type);
+  auto val_ = borrow(val);
+  return release(global::make(store_.it, type_.it, val_.it));
 }
 
-own wasm_val_t wasm_global_get(wasm_global_t* global) {
-  auto store = global->store();
-  auto isolate = store->isolate();
-  v8::HandleScope handle_scope(isolate);
-  auto context = store->context();
+wasm_globaltype_t* wasm_global_type(wasm_global_t* global) {
+  return release(global->type());
+}
 
-  // TODO(wasm+): remove
-  if (store->v8_function(V8_F_GLOBAL_GET).IsEmpty()) {
-    UNIMPLEMENTED("wasm_global_get");
-  }
-
-  auto maybe_val =
-    store->v8_function(V8_F_GLOBAL_GET)->Call(context, global->v8_object(), 0, nullptr);
-  if (maybe_val.IsEmpty()) return wasm_null_val();
-  auto val = maybe_val.ToLocalChecked();
-
-  auto content_type = wasm_globaltype_content(global->type.borrow());
-  return wasm_v8_to_val(store, val, content_type);
+wasm_val_t wasm_global_get(wasm_global_t* global) {
+  return release(global->get());
 }
 
 void wasm_global_set(wasm_global_t* global, wasm_val_t val) {
-  auto store = global->store();
-  auto isolate = store->isolate();
-  v8::HandleScope handle_scope(isolate);
-  auto context = store->context();
-
-  auto content_type = wasm_globaltype_content(global->type.borrow());
-  assert(val.kind == wasm_valtype_kind(content_type));
-
-  // TODO(wasm+): remove
-  if (store->v8_function(V8_F_GLOBAL_SET).IsEmpty()) {
-    UNIMPLEMENTED("wasm_global_set");
-  }
-
-  v8::Local<v8::Value> args[] = { wasm_val_to_v8(store, val) };
-  store->v8_function(V8_F_GLOBAL_SET)->Call(context, global->v8_object(), 1, args);
+  auto val_ = borrow(val);
+  global->set(val_.it);
 }
 
 
 // Table Instances
 
-struct wasm_table_t : wasm_ref_t {
-  owned<wasm_tabletype_t*> type;
-
-  wasm_table_t(wasm_store_t* store, v8::Local<v8::Object> obj, own wasm_tabletype_t* type) :
-    wasm_ref_t(store, obj), type(type) {}
-};
-
 WASM_DEFINE_REF(table)
 
-wasm_table_t* wasm_table_new(wasm_store_t* store, wasm_tabletype_t* type, wasm_ref_t*) {
-  auto isolate = store->isolate();
-  v8::HandleScope handle_scope(isolate);
-  auto context = store->context();
-
-  // TODO(wasm+): handle reference initialiser
-  v8::Local<v8::Value> args[] = { wasm_tabletype_to_v8(store, type) };
-  auto maybe_obj =
-    store->v8_function(V8_F_TABLE)->NewInstance(context, 1, args);
-  if (maybe_obj.IsEmpty()) return nullptr;
-  auto obj = maybe_obj.ToLocalChecked();
-
-  auto type_clone = wasm_tabletype_clone(type);
-  if (type_clone == nullptr) return nullptr;
-  return new wasm_table_t(store, obj, type_clone);
+wasm_table_t* wasm_table_new(wasm_store_t* store, wasm_tabletype_t* type, wasm_ref_t* ref) {
+  auto store_ = borrow(store);
+  auto type_ = borrow(type);
+  auto ref_ = borrow(ref);
+  return release(table::make(store_.it, type_.it, ref_.it));
 }
 
-own wasm_tabletype_t* wasm_table_type(wasm_table_t* table) {
-  // TODO: query and update min
-  return wasm_tabletype_clone(table->type.borrow());
+wasm_tabletype_t* wasm_table_type(wasm_table_t* table) {
+  return release(table->type());
 }
 
-
-own wasm_ref_t* wasm_table_get(wasm_table_t*, wasm_table_size_t index) {
-  UNIMPLEMENTED("wasm_table_get");
+wasm_ref_t* wasm_table_get(wasm_table_t* table, wasm_table_size_t index) {
+  return release(table->get(index));
 }
 
-void wasm_table_set(wasm_table_t*, wasm_table_size_t index, wasm_ref_t*) {
-  UNIMPLEMENTED("wasm_table_set");
+void wasm_table_set(wasm_table_t* table, wasm_table_size_t index, wasm_ref_t* ref) {
+  auto ref_ = borrow(ref);
+  table->set(index, ref_.it);
 }
 
-wasm_table_size_t wasm_table_size(wasm_table_t*) {
-  UNIMPLEMENTED("wasm_table_size");
+wasm_table_size_t wasm_table_size(wasm_table_t* table) {
+  return table->size();
 }
 
-wasm_table_size_t wasm_table_grow(wasm_table_t*, wasm_table_size_t delta) {
-  UNIMPLEMENTED("wasm_table_grow");
+wasm_table_size_t wasm_table_grow(wasm_table_t* table, wasm_table_size_t delta) {
+  return table->grow(delta);
 }
 
 
 // Memory Instances
 
-struct wasm_memory_t : wasm_ref_t {
-  owned<wasm_memtype_t*> type;
-
-  wasm_memory_t(wasm_store_t* store, v8::Local<v8::Object> obj, own wasm_memtype_t* type) :
-    wasm_ref_t(store, obj), type(type) {}
-};
-
 WASM_DEFINE_REF(memory)
 
 wasm_memory_t* wasm_memory_new(wasm_store_t* store, wasm_memtype_t* type) {
-  auto isolate = store->isolate();
-  v8::HandleScope handle_scope(isolate);
-  auto context = store->context();
-
-  v8::Local<v8::Value> args[] = { wasm_memtype_to_v8(store, type) };
-  auto maybe_obj =
-    store->v8_function(V8_F_MEMORY)->NewInstance(context, 1, args);
-  if (maybe_obj.IsEmpty()) return nullptr;
-  auto obj = maybe_obj.ToLocalChecked();
-
-  auto type_clone = wasm_memtype_clone(type);
-  if (type_clone == nullptr) return nullptr;
-  return new wasm_memory_t(store, obj, type_clone);
+  auto store_ = borrow(store);
+  auto type_ = borrow(type);
+  return release(memory::make(store_.it, type_.it));
 }
 
-own wasm_memtype_t* wasm_memory_type(wasm_memory_t* memory) {
-  // TODO: query and update min
-  return wasm_memtype_clone(memory->type.borrow());
+wasm_memtype_t* wasm_memory_type(wasm_memory_t* memory) {
+  return release(memory->type());
 }
 
-wasm_byte_t* wasm_memory_data(wasm_memory_t*) {
-  UNIMPLEMENTED("wasm_memory_data");
+wasm_byte_t* wasm_memory_data(wasm_memory_t* memory) {
+  return memory->data();
 }
 
-size_t wasm_memory_data_size(wasm_memory_t*) {
-  UNIMPLEMENTED("wasm_memory_data_size");
+size_t wasm_memory_data_size(wasm_memory_t* memory) {
+  return memory->data_size();
 }
 
-wasm_memory_pages_t wasm_memory_size(wasm_memory_t*) {
-  UNIMPLEMENTED("wasm_memory_size");
+wasm_memory_pages_t wasm_memory_size(wasm_memory_t* memory) {
+  return memory->size();
 }
 
-wasm_memory_pages_t wasm_memory_grow(wasm_memory_t*, wasm_memory_pages_t delta) {
-  UNIMPLEMENTED("wasm_memory_grow");
+wasm_memory_pages_t wasm_memory_grow(wasm_memory_t* memory, wasm_memory_pages_t delta) {
+  return memory->grow(delta);
 }
 
 
 // Externals
 
-WASM_DEFINE_VEC(extern, )
+WASM_DEFINE_REF(external)
+WASM_DEFINE_VEC(external, *)
 
-extern "C++"
-void delete_own(own wasm_extern_t ex) {
-  switch (ex.kind) {
-    case WASM_EXTERN_FUNC: return wasm_func_delete(ex.func);
-    case WASM_EXTERN_GLOBAL: return wasm_global_delete(ex.global);
-    case WASM_EXTERN_TABLE: return wasm_table_delete(ex.table);
-    case WASM_EXTERN_MEMORY: return wasm_memory_delete(ex.memory);
-  }
+wasm_external_t* wasm_func_as_external(wasm_func_t* func) {
+  return hide(static_cast<wasm::external*>(reveal(func)));
+}
+wasm_external_t* wasm_global_as_external(wasm_global_t* global) {
+  return hide(static_cast<wasm::external*>(reveal(global)));
+}
+wasm_external_t* wasm_table_as_external(wasm_table_t* table) {
+  return hide(static_cast<wasm::external*>(reveal(table)));
+}
+wasm_external_t* wasm_memory_as_external(wasm_memory_t* memory) {
+  return hide(static_cast<wasm::external*>(reveal(memory)));
 }
 
-void wasm_extern_delete(own wasm_extern_t ex) {
-  delete_own(ex);
+wasm_externkind_t wasm_external_kind(wasm_external_t* external) {
+  return hide(external->kind());
 }
 
-own wasm_extern_t wasm_extern_clone(wasm_extern_t ex) {
-  switch (ex.kind) {
-    case WASM_EXTERN_FUNC: return wasm_extern_func(wasm_func_clone(ex.func));
-    case WASM_EXTERN_GLOBAL: return wasm_extern_global(wasm_global_clone(ex.global));
-    case WASM_EXTERN_TABLE: return wasm_extern_table(wasm_table_clone(ex.table));
-    case WASM_EXTERN_MEMORY: return wasm_extern_memory(wasm_memory_clone(ex.memory));
-  }
+wasm_func_t* wasm_external_as_func(wasm_external_t* external) {
+  return hide(external->func());
 }
-
-extern "C++"
-v8::Local<v8::Object> wasm_extern_to_v8(wasm_extern_t ex) {
-  switch (ex.kind) {
-    case WASM_EXTERN_FUNC: return ex.func->v8_object();
-    case WASM_EXTERN_GLOBAL: return ex.global->v8_object();
-    case WASM_EXTERN_TABLE: return ex.table->v8_object();
-    case WASM_EXTERN_MEMORY: return ex.memory->v8_object();
-  }
+wasm_global_t* wasm_external_as_global(wasm_external_t* external) {
+  return hide(external->global());
+}
+wasm_table_t* wasm_external_as_table(wasm_external_t* external) {
+  return hide(external->table());
+}
+wasm_memory_t* wasm_external_as_memory(wasm_external_t* external) {
+  return hide(external->memory());
 }
 
 
 // Module Instances
 
-struct wasm_instance_t : wasm_ref_t {
-  owned<wasm_extern_vec_t> exports;
-
-  wasm_instance_t(wasm_store_t* store, v8::Local<v8::Object> obj, own wasm_extern_vec_t exports) :
-    wasm_ref_t(store, obj), exports(exports) {}
-};
-
 WASM_DEFINE_REF(instance)
 
-own wasm_instance_t* wasm_instance_new(wasm_store_t* store, wasm_module_t* module, wasm_extern_vec_t imports) {
-  auto isolate = store->isolate();
-  auto context = store->context();
-  v8::HandleScope handle_scope(isolate);
-
-  v8::Local<v8::Value> imports_args[] = { module->v8_object() };
-  auto imports_result = store->v8_function(V8_F_IMPORTS)->Call(
-    context, v8::Undefined(isolate), 1, imports_args);
-  if (imports_result.IsEmpty()) return nullptr;
-  auto imports_array = v8::Local<v8::Array>::Cast(imports_result.ToLocalChecked());
-  size_t imports_size = imports_array->Length();
-
-  auto imports_obj = v8::Object::New(isolate);
-  for (size_t i = 0; i < imports_size; ++i) {
-    auto desc = v8::Local<v8::Object>::Cast(imports_array->Get(i));
-    auto module_str = v8::Local<v8::String>::Cast(
-      desc->Get(context, store->v8_string(V8_S_MODULE)).ToLocalChecked());
-    auto name_str = v8::Local<v8::String>::Cast(
-      desc->Get(context, store->v8_string(V8_S_NAME)).ToLocalChecked());
-
-    v8::Local<v8::Object> module_obj;
-    if (imports_obj->HasOwnProperty(context, module_str).ToChecked()) {
-      module_obj = v8::Local<v8::Object>::Cast(
-        imports_obj->Get(context, module_str).ToLocalChecked());
-    } else {
-      module_obj = v8::Object::New(isolate);
-      imports_obj->DefineOwnProperty(context, module_str, module_obj);
-    }
-
-    module_obj->DefineOwnProperty(context, name_str, wasm_extern_to_v8(imports.data[i]));
-  }
-
-  v8::Local<v8::Value> instantiate_args[] = {module->v8_object(), imports_obj};
-  auto instance_obj =
-    store->v8_function(V8_F_INSTANCE)->NewInstance(context, 2, instantiate_args).ToLocalChecked();
-  auto exports_obj = v8::Local<v8::Object>::Cast(
-    instance_obj->Get(context, store->v8_string(V8_S_EXPORTS)).ToLocalChecked());
-  assert(!exports_obj.IsEmpty() && exports_obj->IsObject());
-
-  auto export_types = module->exports.borrow();
-  owned<wasm_extern_vec_t> own_exports =
-    wasm_extern_vec_new_uninitialized(export_types.size);
-  auto exports = own_exports.borrow();
-  for (size_t i = 0; i < export_types.size; ++i) {
-    auto name = export_types.data[i]->name.borrow();
-    auto maybe_name_obj = v8::String::NewFromUtf8(isolate, name.data,
-      v8::NewStringType::kNormal, name.size);
-    if (maybe_name_obj.IsEmpty()) return nullptr;
-    auto name_obj = maybe_name_obj.ToLocalChecked();
-    auto obj = v8::Local<v8::Function>::Cast(
-      exports_obj->Get(context, name_obj).ToLocalChecked());
-
-    auto type = export_types.data[i]->type.borrow();
-    switch (wasm_externtype_kind(type)) {
-      case WASM_EXTERN_FUNC: {
-        auto func_obj = v8::Local<v8::Function>::Cast(obj);
-        auto functype = wasm_functype_clone(wasm_externtype_as_functype(type));
-        if (functype == nullptr) return nullptr;
-        auto func = new wasm_func_t(store, func_obj, functype);
-        exports.data[i] = wasm_extern_func(func);
-      } break;
-      case WASM_EXTERN_GLOBAL: {
-        auto globaltype = wasm_globaltype_clone(wasm_externtype_as_globaltype(type));
-        if (globaltype == nullptr) return nullptr;
-        auto global = new wasm_global_t(store, obj, globaltype);
-        exports.data[i] = wasm_extern_global(global);
-      } break;
-      case WASM_EXTERN_TABLE: {
-        auto tabletype = wasm_tabletype_clone(wasm_externtype_as_tabletype(type));
-        if (tabletype == nullptr) return nullptr;
-        auto table = new wasm_table_t(store, obj, tabletype);
-        exports.data[i] = wasm_extern_table(table);
-      } break;
-      case WASM_EXTERN_MEMORY: {
-        auto memtype = wasm_memtype_clone(wasm_externtype_as_memtype(type));
-        if (memtype == nullptr) return nullptr;
-        auto memory = new wasm_memory_t(store, obj, memtype);
-        exports.data[i] = wasm_extern_memory(memory);
-      } break;
-    }
-  }
-
-  return new wasm_instance_t(store, instance_obj, exports);
+wasm_instance_t* wasm_instance_new(wasm_store_t* store, wasm_module_t* module, wasm_external_vec_t imports) {
+  auto store_ = borrow(store);
+  auto module_ = borrow(module);
+  auto imports_ = borrow(imports);
+  return release(instance::make(store_.it, module_.it, imports_.it));
 }
 
-own wasm_extern_t wasm_instance_export(wasm_instance_t* instance, size_t index) {
-  auto exports = instance->exports.borrow();
-  if (index >= exports.size) return wasm_extern_func(nullptr);
-  return exports.data[index];
-}
-
-own wasm_extern_vec_t wasm_instance_exports(wasm_instance_t* instance) {
-  return wasm_extern_vec_clone(instance->exports.borrow());
+wasm_external_vec_t wasm_instance_exports(wasm_instance_t* instance) {
+  return release(instance->exports());
 }
 
 }  // extern "C"

--- a/src/wasm-v8.cc
+++ b/src/wasm-v8.cc
@@ -124,7 +124,7 @@ public:
     context()->Exit();
     isolate_->Exit();
     isolate_->Dispose();
-    // delete create_params_.array_buffer_allocator;
+    delete create_params_.array_buffer_allocator;
   }
 
   v8::Isolate* isolate() const {
@@ -146,13 +146,6 @@ public:
   v8::Local<v8::Function> v8_function(v8_function_t i) const {
     return functions_[i].Get(isolate_);
   }
-
-/* TODO
-  void cache_set(v8::Local<v8::Object> obj, void* val) {
-    v8::Local<v8::Value> cache_args[] = {???};
-    store->v8_function(V8_F_WEAKSET)->Call(context, cache_, 1, args);
-  }
-*/
 };
 
 template<> struct implement<store> { using type = store_impl; };
@@ -618,7 +611,6 @@ void limits_to_v8(store_impl* store, limits limits, v8::Local<v8::Object> desc) 
 }
 
 v8::Local<v8::Object> globaltype_to_v8(store_impl* store, own<globaltype*>& type) {
-  // TODO: define templates
   auto isolate = store->isolate();
   auto context = store->context();
   auto desc = v8::Object::New(isolate);
@@ -1250,7 +1242,7 @@ auto global::make(own<store*>& store_abs, own<globaltype*>& type, val& val) -> o
 
   // TODO(wasm+): remove
   if (store->v8_function(V8_F_GLOBAL).IsEmpty()) {
-    UNIMPLEMENTED("func::make");
+    UNIMPLEMENTED("global::make");
   }
 
   v8::Local<v8::Value> args[] = {

--- a/src/wasm-v8.cc
+++ b/src/wasm-v8.cc
@@ -36,6 +36,11 @@ auto seal(typename implement <C>::type* x) -> C* {
 }
 
 
+// Vectors
+
+vec_impl<void*>* empty_vec_impl = new(0) vec_impl<void*>(0);
+
+
 ///////////////////////////////////////////////////////////////////////////////
 // Runtime Environment
 
@@ -269,12 +274,30 @@ auto store::make(own<engine*>&) -> own<store*> {
 
 // Value Types
 
+struct valtype_impl {
+  valkind kind;
+
+  valtype_impl(valkind kind) : kind(kind) {}
+};
+
+template<> struct implement<valtype> { using type = valtype_impl; };
+
+valtype_impl* valtypes[] = {
+  new valtype_impl(I32),
+  new valtype_impl(I64),
+  new valtype_impl(F32),
+  new valtype_impl(F64),
+  new valtype_impl(ANYREF),
+  new valtype_impl(FUNCREF),
+};
+
+
 valtype::~valtype() {}
 
 void valtype::operator delete(void*) {}
 
 auto valtype::make(valkind k) -> own<valtype*> {
-  return own<valtype*>(reinterpret_cast<valtype*>(static_cast<intptr_t>(k)));
+  return own<valtype*>(seal<valtype>(valtypes[k]));
 }
 
 auto valtype::clone() const -> own<valtype*> {
@@ -282,7 +305,7 @@ auto valtype::clone() const -> own<valtype*> {
 }
 
 auto valtype::kind() const -> valkind {
-  return static_cast<valkind>(reinterpret_cast<intptr_t>(this));
+  return impl(this)->kind;
 }
 
 


### PR DESCRIPTION
* Add a C++ version of the API
* Refactor wasm-v8 to implement C++ API, which is safer
* Reimplement C API on top of C++ API
* Various fixes, additions, and clean-ups
* Some minor changes to C API:
  * Replace `init`, `deinit` global functions with `engine` object to be created
  * Store creation requires engine object
  * Add `wasm_*_vec_new_empty` functions for creating *own* vectors of size 0
  * Changed `wasm_limits_t` from `size_t` to `uint32_t`
  * Changed `wasm_val_t` from `uint32_t`, `uint64_t` to `int32_t`, `int64_t`
  * Removed `wasm_numkind_t`, `wasm_refkind_t` and `wasm_numtype_t` `wasm_reftype_t` type aliases
  * Renamed `wasm_valkind_is_numkind`, `wasm_valkind_is_refkind` to `wasm_valkind_is_num`, `wasm_valkind_is_ref` and `wasm_valtype_is_numtype`, `wasm_valtype_is_reftype` to `wasm_valtype_is_num`, `wasm_valtype_is_ref`
  * Removed `wasm_ref_null` and `wasm_ref_is_null` (use NULL pointer)
  * Extended `wasm_func_new_with_env` function to take finalizer for env (which may be NULL)
  * Turned `wasm_extern_t` into an abstract type `wasm_external_t` and added conversion functions
  * Removed `wasm_instance_export` function
