### PR TITLE
Add include for cassert

### DIFF
--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -3,6 +3,7 @@
 #ifndef __WASM_HH
 #define __WASM_HH
 
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <memory>


### PR DESCRIPTION
This commit includes cassert in wasm.hh. The motivation for this is that
compiling on my system currently reports the following errors (only
showing one of the errors below):
```shell
/include/wasm.hh:479:33: error: use of undeclared identifier 'assert'
  auto i64() const -> int64_t { assert(kind_ == I64); return impl_.i64; }
```