### PR TITLE
More consistent naming conventions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,15 +39,16 @@ V8_BIN = natives_blob snapshot_blob snapshot_blob_trusted
 
 .PHONY: all c cc
 all: c cc
-	@echo ==== Done ====
 
 c: ${EXAMPLE_OUT}/${EXAMPLE_NAME}-c ${V8_BIN:%=${EXAMPLE_OUT}/%.bin} ${EXAMPLE_WAT:%=${EXAMPLE_OUT}/%.wasm}
 	@echo ==== C ====; \
 	cd ${EXAMPLE_OUT}; ./${EXAMPLE_NAME}-c
+	@echo ==== Done ====
 
 cc: ${EXAMPLE_OUT}/${EXAMPLE_NAME}-cc ${V8_BIN:%=${EXAMPLE_OUT}/%.bin} ${EXAMPLE_WAT:%=${EXAMPLE_OUT}/%.wasm}
 	@echo ==== C++ ====; \
 	cd ${EXAMPLE_OUT}; ./${EXAMPLE_NAME}-cc
+	@echo ==== Done ====
 
 ${EXAMPLE_OUT}/${EXAMPLE_NAME}.c.o: ${EXAMPLE_DIR}/${EXAMPLE_NAME}.c ${WASM_INCLUDE}/wasm.h
 	mkdir -p ${EXAMPLE_OUT}

--- a/README.md
+++ b/README.md
@@ -41,10 +41,4 @@ Work in progress. No docs yet.
 
   * Find a way to perform C callbacks through C++ without extra wrapper?
 
-  * Possible renamings?
-
-    * `externkind`, `externtype` to `externalkind`, `externaltype`?
-    * `memtype` to `memorytype`?
-    * CamlCase class names in C++ API?
-
   * Add iterators to `vec` class?

--- a/example/hello.c
+++ b/example/hello.c
@@ -90,10 +90,10 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_external_t* imports[] = {
-    wasm_func_as_external(print_func1), wasm_func_as_external(print_func2)
+  const wasm_extern_t* imports[] = {
+    wasm_func_as_extern(print_func1), wasm_func_as_extern(print_func2)
   };
-  own wasm_instance_t* instance = wasm_instance_new(store, module, wasm_external_vec_const(2, imports));
+  own wasm_instance_t* instance = wasm_instance_new(store, module, wasm_extern_vec_const(2, imports));
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -101,12 +101,12 @@ int main(int argc, const char* argv[]) {
 
   // Extract export.
   printf("Extracting exports...\n");
-  own wasm_external_vec_t exports = wasm_instance_exports(instance);
+  own wasm_extern_vec_t exports = wasm_instance_exports(instance);
   if (exports.size == 0) {
     printf("> Error accessing exports!\n");
     return 1;
   }
-  const wasm_func_t* run_func = wasm_external_as_func(exports.data[0]);
+  const wasm_func_t* run_func = wasm_extern_as_func(exports.data[0]);
   if (run_func == NULL) {
     printf("> Error accessing export!\n");
     return 1;
@@ -120,7 +120,7 @@ int main(int argc, const char* argv[]) {
   wasm_val_t args[] = { wasm_i32_val(3), wasm_i32_val(4) };
   own wasm_val_vec_t results = wasm_func_call(run_func, wasm_val_vec(2, args));
 
-  wasm_external_vec_delete(exports);
+  wasm_extern_vec_delete(exports);
 
   // Print result.
   printf("Printing result...\n");

--- a/example/hello.cc
+++ b/example/hello.cc
@@ -7,7 +7,7 @@
 #include "wasm.hh"
 
 // Print a Wasm value
-void val_print(const wasm::val& val) {
+void val_print(const wasm::Val& val) {
   switch (val.kind()) {
     case wasm::I32: {
       std::cout << val.i32();
@@ -33,7 +33,7 @@ void val_print(const wasm::val& val) {
 }
 
 // A function to be called from Wasm code.
-auto print_wasm(const wasm::vec<wasm::val>& args) -> wasm::vec<wasm::val> {
+auto print_wasm(const wasm::vec<wasm::Val>& args) -> wasm::vec<wasm::Val> {
   std::cout << "Calling back..." << std::endl << ">";
   for (size_t i = 0; i < args.size(); ++i) {
     std::cout << " ";
@@ -42,15 +42,15 @@ auto print_wasm(const wasm::vec<wasm::val>& args) -> wasm::vec<wasm::val> {
   std::cout << std::endl;
 
   int32_t n = args.size();
-  return wasm::vec<wasm::val>::make(wasm::val(n));
+  return wasm::vec<wasm::Val>::make(wasm::Val(n));
 }
 
 
 void run(int argc, const char* argv[]) {
   // Initialize.
   std::cout << "Initializing..." << std::endl;
-  auto engine = wasm::engine::make(argc, argv);
-  auto store = wasm::store::make(engine);
+  auto engine = wasm::Engine::make(argc, argv);
+  auto store = wasm::Store::make(engine);
 
   // Load binary.
   std::cout << "Loading binary..." << std::endl;
@@ -68,7 +68,7 @@ void run(int argc, const char* argv[]) {
 
   // Compile.
   std::cout << "Compiling module..." << std::endl;
-  auto module = wasm::module::make(store, binary);
+  auto module = wasm::Module::make(store, binary);
   if (!module) {
     std::cout << "> Error compiling module!" << std::endl;
     return;
@@ -76,22 +76,22 @@ void run(int argc, const char* argv[]) {
 
   // Create external print functions.
   std::cout << "Creating callbacks..." << std::endl;
-  auto print_type1 = wasm::functype::make(
-    wasm::vec<wasm::valtype*>::make(wasm::valtype::make(wasm::I32)),
-    wasm::vec<wasm::valtype*>::make(wasm::valtype::make(wasm::I32))
+  auto print_type1 = wasm::FuncType::make(
+    wasm::vec<wasm::ValType*>::make(wasm::ValType::make(wasm::I32)),
+    wasm::vec<wasm::ValType*>::make(wasm::ValType::make(wasm::I32))
   );
-  auto print_func1 = wasm::func::make(store, print_type1, print_wasm);
+  auto print_func1 = wasm::Func::make(store, print_type1, print_wasm);
 
-  auto print_type2 = wasm::functype::make(
-    wasm::vec<wasm::valtype*>::make(wasm::valtype::make(wasm::I32), wasm::valtype::make(wasm::I32)),
-    wasm::vec<wasm::valtype*>::make(wasm::valtype::make(wasm::I32))
+  auto print_type2 = wasm::FuncType::make(
+    wasm::vec<wasm::ValType*>::make(wasm::ValType::make(wasm::I32), wasm::ValType::make(wasm::I32)),
+    wasm::vec<wasm::ValType*>::make(wasm::ValType::make(wasm::I32))
   );
-  auto print_func2 = wasm::func::make(store, print_type2, print_wasm);
+  auto print_func2 = wasm::Func::make(store, print_type2, print_wasm);
 
   // Instantiate.
   std::cout << "Instantiating module..." << std::endl;
-  auto imports = wasm::vec<wasm::external*>::make(print_func1, print_func2);
-  auto instance = wasm::instance::make(store, module, imports);
+  auto imports = wasm::vec<wasm::Extern*>::make(print_func1, print_func2);
+  auto instance = wasm::Instance::make(store, module, imports);
   if (!instance) {
     std::cout << "> Error instantiating module!" << std::endl;
     return;
@@ -108,7 +108,7 @@ void run(int argc, const char* argv[]) {
 
   // Call.
   std::cout << "Calling exports..." << std::endl;
-  auto results = run_func->call(wasm::val(3), wasm::val(4));
+  auto results = run_func->call(wasm::Val(3), wasm::Val(4));
 
   // Print result.
   std::cout << "Printing result..." << std::endl;

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -81,7 +81,7 @@ typedef double float64_t;
   own wasm_##name##_vec_t wasm_##name##_vec_new_empty(); \
   own wasm_##name##_vec_t wasm_##name##_vec_new_uninitialized(size_t); \
   own wasm_##name##_vec_t wasm_##name##_vec_new(size_t, own wasm_##name##_t ptr_or_none const[]); \
-  own wasm_##name##_vec_t wasm_##name##_vec_clone(wasm_##name##_vec_t); \
+  own wasm_##name##_vec_t wasm_##name##_vec_copy(wasm_##name##_vec_t); \
   void wasm_##name##_vec_delete(own wasm_##name##_vec_t);
 
 
@@ -96,7 +96,7 @@ typedef wasm_byte_vec_t wasm_name_t;
 #define wasm_name_new wasm_byte_vec_new
 #define wasm_name_new_empty wasm_byte_vec_new_empty
 #define wasm_name_new_new_uninitialized wasm_byte_vec_new_uninitialized
-#define wasm_name_clone wasm_byte_vec_clone
+#define wasm_name_copy wasm_byte_vec_copy
 #define wasm_name_delete wasm_byte_vec_delete
 
 static inline own wasm_name_t wasm_name_new_from_string(const char* s) {
@@ -159,7 +159,7 @@ static inline wasm_limits_t wasm_limits_no_max(uint32_t min) {
   WASM_DECLARE_OWN(name) \
   WASM_DECLARE_VEC(name, *) \
   \
-  own wasm_##name##_t* wasm_##name##_clone(wasm_##name##_t*);
+  own wasm_##name##_t* wasm_##name##_copy(wasm_##name##_t*);
 
 
 // Value Types
@@ -290,29 +290,30 @@ typedef struct wasm_val_t {
 } wasm_val_t;
 
 void wasm_val_delete(own wasm_val_t v);
-own wasm_val_t wasm_val_clone(wasm_val_t);
+own wasm_val_t wasm_val_copy(wasm_val_t);
 
 WASM_DECLARE_VEC(val, )
 
 
 // References
 
-WASM_DECLARE_OWN(ref)
-
-own wasm_ref_t* wasm_ref_clone(wasm_ref_t*);
-
-
-#define WASM_DECLARE_REF(name) \
+#define WASM_DECLARE_REF_BASE(name) \
   WASM_DECLARE_OWN(name) \
   \
-  own wasm_##name##_t* wasm_##name##_clone(const wasm_##name##_t*); \
-  \
-  const wasm_ref_t* wasm_##name##_as_ref(const wasm_##name##_t*); \
-  const wasm_##name##_t* wasm_ref_as_##name(const wasm_ref_t*); \
+  own wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t*); \
   \
   void* wasm_##name##_get_host_info(const wasm_##name##_t*); \
   void wasm_##name##_set_host_info(wasm_##name##_t*, void*); \
   void wasm_##name##_set_host_info_with_finalizer(wasm_##name##_t*, void*, void (*)(void*));
+
+#define WASM_DECLARE_REF(name) \
+  WASM_DECLARE_REF_BASE(name) \
+  \
+  const wasm_ref_t* wasm_##name##_as_ref(const wasm_##name##_t*); \
+  const wasm_##name##_t* wasm_ref_as_##name(const wasm_ref_t*);
+
+
+WASM_DECLARE_REF_BASE(ref)
 
 
 // Modules

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -136,7 +136,7 @@ own wasm_store_t* wasm_store_new(wasm_engine_t*);
 
 // Tyoe atributes
 
-typedef enum wasm_mut_t { WASM_CONST, WASM_VAR } wasm_mut_t;
+typedef enum wasm_mutability_t { WASM_CONST, WASM_VAR } wasm_mutability_t;
 
 typedef struct wasm_limits_t {
   uint32_t min;
@@ -204,10 +204,10 @@ const wasm_valtype_vec_t wasm_functype_results(const wasm_functype_t*);
 
 WASM_DECLARE_TYPE(globaltype)
 
-own wasm_globaltype_t* wasm_globaltype_new(own wasm_valtype_t*, wasm_mut_t);
+own wasm_globaltype_t* wasm_globaltype_new(own wasm_valtype_t*, wasm_mutability_t);
 
 const wasm_valtype_t* wasm_globaltype_content(const wasm_globaltype_t*);
-wasm_mut_t wasm_globaltype_mut(const wasm_globaltype_t*);
+wasm_mutability_t wasm_globaltype_mutability(const wasm_globaltype_t*);
 
 
 // Table Types
@@ -222,11 +222,11 @@ wasm_limits_t wasm_tabletype_limits(const wasm_tabletype_t*);
 
 // Memory Types
 
-WASM_DECLARE_TYPE(memtype)
+WASM_DECLARE_TYPE(memorytype)
 
-own wasm_memtype_t* wasm_memtype_new(wasm_limits_t);
+own wasm_memorytype_t* wasm_memorytype_new(wasm_limits_t);
 
-wasm_limits_t wasm_memtype_limits(const wasm_memtype_t*);
+wasm_limits_t wasm_memorytype_limits(const wasm_memorytype_t*);
 
 
 // Extern Types
@@ -240,14 +240,14 @@ typedef enum wasm_externkind_t {
 const wasm_externtype_t* wasm_functype_as_externtype(const wasm_functype_t*);
 const wasm_externtype_t* wasm_globaltype_as_externtype(const wasm_globaltype_t*);
 const wasm_externtype_t* wasm_tabletype_as_externtype(const wasm_tabletype_t*);
-const wasm_externtype_t* wasm_memtype_as_externtype(const wasm_memtype_t*);
+const wasm_externtype_t* wasm_memorytype_as_externtype(const wasm_memorytype_t*);
 
 wasm_externkind_t wasm_externtype_kind(const wasm_externtype_t*);
 
 const wasm_functype_t* wasm_externtype_as_functype(const wasm_externtype_t*);
 const wasm_globaltype_t* wasm_externtype_as_globaltype(const wasm_externtype_t*);
 const wasm_tabletype_t* wasm_externtype_as_tabletype(const wasm_externtype_t*);
-const wasm_memtype_t* wasm_externtype_as_memtype(const wasm_externtype_t*);
+const wasm_memorytype_t* wasm_externtype_as_memorytype(const wasm_externtype_t*);
 
 
 // Import Types
@@ -331,11 +331,11 @@ own wasm_byte_vec_t wasm_module_serialize(const wasm_module_t*);
 own wasm_module_t* wasm_module_deserialize(wasm_byte_vec_t);
 
 
-// Host Objects
+// Foreign Objects
 
-WASM_DECLARE_REF(hostobj)
+WASM_DECLARE_REF(foreign)
 
-own wasm_hostobj_t* wasm_hostobj_new(wasm_store_t*);
+own wasm_foreign_t* wasm_foreign_new(wasm_store_t*);
 
 
 // Function Instances
@@ -390,9 +390,9 @@ typedef uint32_t wasm_memory_pages_t;
 
 static const size_t MEMORY_PAGE_SIZE = 0x10000;
 
-own wasm_memory_t* wasm_memory_new(wasm_store_t*, const wasm_memtype_t*);
+own wasm_memory_t* wasm_memory_new(wasm_store_t*, const wasm_memorytype_t*);
 
-own wasm_memtype_t* wasm_memory_type(const wasm_memory_t*);
+own wasm_memorytype_t* wasm_memory_type(const wasm_memory_t*);
 
 byte_t* wasm_memory_data(wasm_memory_t*);
 size_t wasm_memory_data_size(const wasm_memory_t*);
@@ -403,29 +403,29 @@ wasm_memory_pages_t wasm_memory_grow(wasm_memory_t*, wasm_memory_pages_t delta);
 
 // Externals
 
-WASM_DECLARE_REF(external)
-WASM_DECLARE_VEC(external, *)
+WASM_DECLARE_REF(extern)
+WASM_DECLARE_VEC(extern, *)
 
-const wasm_external_t* wasm_func_as_external(const wasm_func_t*);
-const wasm_external_t* wasm_global_as_external(const wasm_global_t*);
-const wasm_external_t* wasm_table_as_external(const wasm_table_t*);
-const wasm_external_t* wasm_memory_as_external(const wasm_memory_t*);
+const wasm_extern_t* wasm_func_as_extern(const wasm_func_t*);
+const wasm_extern_t* wasm_global_as_extern(const wasm_global_t*);
+const wasm_extern_t* wasm_table_as_extern(const wasm_table_t*);
+const wasm_extern_t* wasm_memory_as_extern(const wasm_memory_t*);
 
-wasm_externkind_t wasm_external_kind(const wasm_external_t*);
+wasm_externkind_t wasm_extern_kind(const wasm_extern_t*);
 
-const wasm_func_t* wasm_external_as_func(const wasm_external_t*);
-const wasm_global_t* wasm_external_as_global(const wasm_external_t*);
-const wasm_table_t* wasm_external_as_table(const wasm_external_t*);
-const wasm_memory_t* wasm_external_as_memory(const wasm_external_t*);
+const wasm_func_t* wasm_extern_as_func(const wasm_extern_t*);
+const wasm_global_t* wasm_extern_as_global(const wasm_extern_t*);
+const wasm_table_t* wasm_extern_as_table(const wasm_extern_t*);
+const wasm_memory_t* wasm_extern_as_memory(const wasm_extern_t*);
 
 
 // Module Instances
 
 WASM_DECLARE_REF(instance)
 
-own wasm_instance_t* wasm_instance_new(wasm_store_t*, const wasm_module_t*, const wasm_external_vec_t imports);
+own wasm_instance_t* wasm_instance_new(wasm_store_t*, const wasm_module_t*, const wasm_extern_vec_t imports);
 
-own wasm_external_vec_t wasm_instance_exports(const wasm_instance_t*);
+own wasm_extern_vec_t wasm_instance_exports(const wasm_instance_t*);
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -198,39 +198,39 @@ public:
 
 // Configuration
 
-class config {
+class Config {
 public:
-  config() = delete;
-  ~config();
+  Config() = delete;
+  ~Config();
   void operator delete(void*);
 
-  static auto make() -> own<config*>;
+  static auto make() -> own<Config*>;
 
-  // Embedders may provide custom methods for manipulating configs.
+  // Embedders may provide custom methods for manipulating Configs.
 };
 
 
 // Engine
 
-class engine {
+class Engine {
 public:
-  engine() = delete;
-  ~engine();
+  Engine() = delete;
+  ~Engine();
   void operator delete(void*);
 
-  static auto make(int argc, const char* const argv[], own<config*>&& = config::make()) -> own<engine*>;
+  static auto make(int argc, const char* const argv[], own<Config*>&& = Config::make()) -> own<Engine*>;
 };
 
 
 // Store
 
-class store {
+class Store {
 public:
-  store() = delete;
-  ~store();
+  Store() = delete;
+  ~Store();
   void operator delete(void*);
 
-  static auto make(own<engine*>&) -> own<store*>;
+  static auto make(own<Engine*>&) -> own<Store*>;
 };
 
 
@@ -239,35 +239,35 @@ public:
 
 // Tyoe atributes
 
-enum mut { CONST, VAR };
+enum Mutability { CONST, VAR };
 
-struct limits {
+struct Limits {
   uint32_t min;
   uint32_t max;
 
-  limits(uint32_t min, uint32_t max = std::numeric_limits<uint32_t>::max()) :
+  Limits(uint32_t min, uint32_t max = std::numeric_limits<uint32_t>::max()) :
     min(min), max(max) {}
 };
 
 
 // Value Types
 
-enum valkind { I32, I64, F32, F64, ANYREF, FUNCREF };
+enum ValKind { I32, I64, F32, F64, ANYREF, FUNCREF };
 
-inline bool is_num(valkind k) { return k < ANYREF; }
-inline bool is_ref(valkind k) { return k >= ANYREF; }
+inline bool is_num(ValKind k) { return k < ANYREF; }
+inline bool is_ref(ValKind k) { return k >= ANYREF; }
 
 
-class valtype {
+class ValType {
 public:
-  valtype() = delete;
-  ~valtype();
+  ValType() = delete;
+  ~ValType();
   void operator delete(void*);
 
-  static auto make(valkind) -> own<valtype*>;
-  auto copy() const -> own<valtype*>;
+  static auto make(ValKind) -> own<ValType*>;
+  auto copy() const -> own<ValType*>;
 
-  auto kind() const -> valkind;
+  auto kind() const -> ValKind;
   auto is_num() const -> bool { return wasm::is_num(kind()); }
   auto is_ref() const -> bool { return wasm::is_ref(kind()); }
 };
@@ -275,34 +275,34 @@ public:
 
 // External Types
 
-enum externkind {
+enum ExternKind {
   EXTERN_FUNC, EXTERN_GLOBAL, EXTERN_TABLE, EXTERN_MEMORY
 };
 
-class functype;
-class globaltype;
-class tabletype;
-class memtype;
+class FuncType;
+class GlobalType;
+class TableType;
+class MemoryType;
 
-class externtype {
+class ExternType {
 public:
-  externtype() = delete;
-  ~externtype();
+  ExternType() = delete;
+  ~ExternType();
   void operator delete(void*);
 
-  auto copy() const-> own<externtype*>;
+  auto copy() const-> own<ExternType*>;
 
-  auto kind() const -> externkind;
+  auto kind() const -> ExternKind;
 
-  auto func() -> functype*;
-  auto global() -> globaltype*;
-  auto table() -> tabletype*;
-  auto memory() -> memtype*;
+  auto func() -> FuncType*;
+  auto global() -> GlobalType*;
+  auto table() -> TableType*;
+  auto memory() -> MemoryType*;
 
-  auto func() const -> const functype*;
-  auto global() const -> const globaltype*;
-  auto table() const -> const tabletype*;
-  auto memory() const -> const memtype*;
+  auto func() const -> const FuncType*;
+  auto global() const -> const GlobalType*;
+  auto table() const -> const TableType*;
+  auto memory() const -> const MemoryType*;
 };
 
 
@@ -310,99 +310,99 @@ public:
 
 enum class arrow { ARROW };
 
-class functype : public externtype {
+class FuncType : public ExternType {
 public:
-  functype() = delete;
-  ~functype();
+  FuncType() = delete;
+  ~FuncType();
 
   static auto make(
-    vec<valtype*>&& params = vec<valtype*>::make(),
-    vec<valtype*>&& results = vec<valtype*>::make()
-  ) -> own<functype*>;
+    vec<ValType*>&& params = vec<ValType*>::make(),
+    vec<ValType*>&& results = vec<ValType*>::make()
+  ) -> own<FuncType*>;
 
-  auto copy() const -> own<functype*>;
+  auto copy() const -> own<FuncType*>;
 
-  auto params() const -> const vec<valtype*>&;
-  auto results() const -> const vec<valtype*>&;
+  auto params() const -> const vec<ValType*>&;
+  auto results() const -> const vec<ValType*>&;
 };
 
 
 // Global Types
 
-class globaltype : public externtype {
+class GlobalType : public ExternType {
 public:
-  globaltype() = delete;
-  ~globaltype();
+  GlobalType() = delete;
+  ~GlobalType();
 
-  static auto make(own<valtype*>&&, mut) -> own<globaltype*>;
-  auto copy() const -> own<globaltype*>;
+  static auto make(own<ValType*>&&, Mutability) -> own<GlobalType*>;
+  auto copy() const -> own<GlobalType*>;
 
-  auto content() const -> const own<valtype*>&;
-  auto mut() const -> mut;
+  auto content() const -> const own<ValType*>&;
+  auto mutability() const -> Mutability;
 };
 
 
 // Table Types
 
-class tabletype : public externtype {
+class TableType : public ExternType {
 public:
-  tabletype() = delete;
-  ~tabletype();
+  TableType() = delete;
+  ~TableType();
 
-  static auto make(own<valtype*>&&, limits) -> own<tabletype*>;
-  auto copy() const -> own<tabletype*>;
+  static auto make(own<ValType*>&&, Limits) -> own<TableType*>;
+  auto copy() const -> own<TableType*>;
 
-  auto element() const -> const own<valtype*>&;
-  auto limits() const -> limits;
+  auto element() const -> const own<ValType*>&;
+  auto limits() const -> Limits;
 };
 
 
 // Memory Types
 
-class memtype : public externtype {
+class MemoryType : public ExternType {
 public:
-  memtype() = delete;
-  ~memtype();
+  MemoryType() = delete;
+  ~MemoryType();
 
-  static auto make(limits) -> own<memtype*>;
-  auto copy() const -> own<memtype*>;
+  static auto make(Limits) -> own<MemoryType*>;
+  auto copy() const -> own<MemoryType*>;
 
-  auto limits() const -> limits;
+  auto limits() const -> Limits;
 };
 
 
 // Import Types
 
-using name = vec<byte_t>;
+using Name = vec<byte_t>;
 
-class importtype {
+class ImportType {
 public:
-  importtype() = delete;
-  ~importtype();
+  ImportType() = delete;
+  ~ImportType();
   void operator delete(void*);
 
-  static auto make(name&& module, name&& name, own<externtype*>&&) -> own<importtype*>;
-  auto copy() const -> own<importtype*>;
+  static auto make(Name&& module, Name&& name, own<ExternType*>&&) -> own<ImportType*>;
+  auto copy() const -> own<ImportType*>;
 
-  auto module() const -> const name&;
-  auto name() const -> const name&;
-  auto type() const -> const own<externtype*>&;
+  auto module() const -> const Name&;
+  auto name() const -> const Name&;
+  auto type() const -> const own<ExternType*>&;
 };
 
 
 // Export Types
 
-class exporttype {
+class ExportType {
 public:
-  exporttype() = delete;
-  ~exporttype();
+  ExportType() = delete;
+  ~ExportType();
   void operator delete(void*);
 
-  static auto make(name&& name, own<externtype*>&&) -> own<exporttype*>;
-  auto copy() const -> own<exporttype*>;
+  static auto make(Name&&, own<ExternType*>&&) -> own<ExportType*>;
+  auto copy() const -> own<ExportType*>;
 
-  auto name() const -> const name&;
-  auto type() const -> const own<externtype*>&;
+  auto name() const -> const Name&;
+  auto type() const -> const own<ExternType*>&;
 };
 
 
@@ -411,13 +411,13 @@ public:
 
 // References
 
-class ref {
+class Ref {
 public:
-  ref() = delete;
-  ~ref();
+  Ref() = delete;
+  ~Ref();
   void operator delete(void*);
 
-  auto copy() const -> own<ref*>;
+  auto copy() const -> own<Ref*>;
 
   auto get_host_info() const -> void*;
   void set_host_info(void* info, void (*finalizer)(void*) = nullptr);
@@ -426,31 +426,31 @@ public:
 
 // Values
 
-class val {
-  valkind kind_;
+class Val {
+  ValKind kind_;
   union impl {
     int32_t i32;
     int64_t i64;
     float32_t f32;
     float64_t f64;
-    wasm::ref* ref;
+    Ref* ref;
   } impl_;
 
-  val(valkind kind, impl impl) : kind_(kind), impl_(impl) {}
+  Val(ValKind kind, impl impl) : kind_(kind), impl_(impl) {}
 
 public:
-  val() : kind_(ANYREF) { impl_.ref = nullptr; }
-  val(int32_t i) : kind_(I32) { impl_.i32 = i; }
-  val(int64_t i) : kind_(I64) { impl_.i64 = i; }
-  val(float32_t z) : kind_(F32) { impl_.f32 = z; }
-  val(float64_t z) : kind_(F64) { impl_.f64 = z; }
-  val(own<wasm::ref*>&& r) : kind_(ANYREF) { impl_.ref = r.release(); }
+  Val() : kind_(ANYREF) { impl_.ref = nullptr; }
+  Val(int32_t i) : kind_(I32) { impl_.i32 = i; }
+  Val(int64_t i) : kind_(I64) { impl_.i64 = i; }
+  Val(float32_t z) : kind_(F32) { impl_.f32 = z; }
+  Val(float64_t z) : kind_(F64) { impl_.f64 = z; }
+  Val(own<Ref*>&& r) : kind_(ANYREF) { impl_.ref = r.release(); }
 
-  val(val&& that) : kind_(that.kind_), impl_(that.impl_) {
+  Val(Val&& that) : kind_(that.kind_), impl_(that.impl_) {
     if (is_ref(kind_)) that.impl_.ref = nullptr;
   }
 
-  ~val() {
+  ~Val() {
     reset();
   }
 
@@ -461,38 +461,38 @@ public:
     }
   }
 
-  void reset(val& that) {
+  void reset(Val& that) {
     reset();
     kind_ = that.kind_;
     impl_ = that.impl_;
     if (is_ref(kind_)) that.impl_.ref = nullptr;
   }
 
-  auto operator=(val&& that) -> val& {
+  auto operator=(Val&& that) -> Val& {
     reset(that);
     return *this;
   } 
 
-  auto kind() const -> valkind { return kind_; }
+  auto kind() const -> ValKind { return kind_; }
   auto i32() const -> int32_t { assert(kind_ == I32); return impl_.i32; }
   auto i64() const -> int64_t { assert(kind_ == I64); return impl_.i64; }
   auto f32() const -> float32_t { assert(kind_ == F32); return impl_.f32; }
   auto f64() const -> float64_t { assert(kind_ == F64); return impl_.f64; }
-  auto ref() const -> wasm::ref* { assert(is_ref(kind_)); return impl_.ref; }
+  auto ref() const -> Ref* { assert(is_ref(kind_)); return impl_.ref; }
 
-  auto release_ref() -> own<wasm::ref*> {
+  auto release_ref() -> own<Ref*> {
     assert(is_ref(kind_));
     auto ref = impl_.ref;
     ref = nullptr;
-    return own<wasm::ref*>(ref);
+    return own<Ref*>(ref);
   }
 
-  auto copy() const -> val {
+  auto copy() const -> Val {
     if (is_ref(kind_) && impl_.ref != nullptr) {
       impl impl = {.ref = impl_.ref->copy().release()};
-      return val(kind_, impl);
+      return Val(kind_, impl);
     } else {
-      return val(kind_, impl_);
+      return Val(kind_, impl_);
     }
   }
 };
@@ -500,118 +500,118 @@ public:
 
 // Modules
 
-class module : public ref {
+class Module : public Ref {
 public:
-  module() = delete;
-  ~module();
+  Module() = delete;
+  ~Module();
 
-  static auto validate(own<store*>& store, const vec<byte_t>& binary) -> bool;
-  static auto make(own<store*>& store, const vec<byte_t>& binary) -> own<module*>;
-  auto copy() const -> own<module*>;
+  static auto validate(own<Store*>&, const vec<byte_t>& binary) -> bool;
+  static auto make(own<Store*>&, const vec<byte_t>& binary) -> own<Module*>;
+  auto copy() const -> own<Module*>;
 
-  auto imports() const -> vec<importtype*>;
-  auto exports() const -> vec<exporttype*>;
+  auto imports() const -> vec<ImportType*>;
+  auto exports() const -> vec<ExportType*>;
 
   auto serialize() const -> vec<byte_t>;
-  static auto deserialize(vec<byte_t>&) -> own<module*>;
+  static auto deserialize(vec<byte_t>&) -> own<Module*>;
 };
 
 
-// Host Objects
+// Foreign Objects
 
-class hostobj : public ref {
+class Foreign : public Ref {
 public:
-  hostobj() = delete;
-  ~hostobj();
+  Foreign() = delete;
+  ~Foreign();
 
-  static auto make(own<store*>&) -> own<hostobj*>;
-  auto copy() const -> own<hostobj*>;
+  static auto make(own<Store*>&) -> own<Foreign*>;
+  auto copy() const -> own<Foreign*>;
 };
 
 
 // Externals
 
-class func;
-class global;
-class table;
-class memory;
+class Func;
+class Global;
+class Table;
+class Memory;
 
-class external : public ref {
+class Extern : public Ref {
 public:
-  external() = delete;
-  ~external();
+  Extern() = delete;
+  ~Extern();
 
-  auto copy() const -> own<external*>;
+  auto copy() const -> own<Extern*>;
 
-  auto kind() const -> externkind;
+  auto kind() const -> ExternKind;
 
-  auto func() -> wasm::func*;
-  auto global() -> wasm::global*;
-  auto table() -> wasm::table*;
-  auto memory() -> wasm::memory*;
+  auto func() -> Func*;
+  auto global() -> Global*;
+  auto table() -> Table*;
+  auto memory() -> Memory*;
 
-  auto func() const -> const wasm::func*;
-  auto global() const -> const wasm::global*;
-  auto table() const -> const wasm::table*;
-  auto memory() const -> const wasm::memory*;
+  auto func() const -> const Func*;
+  auto global() const -> const Global*;
+  auto table() const -> const Table*;
+  auto memory() const -> const Memory*;
 };
 
 
 // Function Instances
 
-class func : public external {
+class Func : public Extern {
 public:
-  func() = delete;
-  ~func();
+  Func() = delete;
+  ~Func();
 
-  using callback = auto (*)(const vec<val>&) -> vec<val>;
-  using callback_with_env = auto (*)(void*, const vec<val>&) -> vec<val>;
+  using callback = auto (*)(const vec<Val>&) -> vec<Val>;
+  using callback_with_env = auto (*)(void*, const vec<Val>&) -> vec<Val>;
 
-  static auto make(own<store*>&, const own<functype*>&, callback) -> own<func*>;
-  static auto make(own<store*>&, const own<functype*>&, callback_with_env, void*, void (*finalizer)(void*) = nullptr) -> own<func*>;
-  auto copy() const -> own<func*>;
+  static auto make(own<Store*>&, const own<FuncType*>&, callback) -> own<Func*>;
+  static auto make(own<Store*>&, const own<FuncType*>&, callback_with_env, void*, void (*finalizer)(void*) = nullptr) -> own<Func*>;
+  auto copy() const -> own<Func*>;
 
-  auto type() const -> own<functype*>;
-  auto call(const vec<val>&) const -> vec<val>;
+  auto type() const -> own<FuncType*>;
+  auto call(const vec<Val>&) const -> vec<Val>;
 
   template<class... Args>
-  auto call(const Args&... vals) const -> vec<val> {
-    return call(vec<val>::make(vals.copy()...));
+  auto call(const Args&... vals) const -> vec<Val> {
+    return call(vec<Val>::make(vals.copy()...));
   }
 };
 
 
 // Global Instances
 
-class global : public external {
+class Global : public Extern {
 public:
-  global() = delete;
-  ~global();
+  Global() = delete;
+  ~Global();
 
-  static auto make(own<store*>&, const own<globaltype*>&, const val&) -> own<global*>;
-  auto copy() const -> own<global*>;
+  static auto make(own<Store*>&, const own<GlobalType*>&, const Val&) -> own<Global*>;
+  auto copy() const -> own<Global*>;
 
-  auto type() const -> own<globaltype*>;
-  auto get() const -> val;
-  void set(const val&);
+  auto type() const -> own<GlobalType*>;
+  auto get() const -> Val;
+  void set(const Val&);
 };
 
 
 // Table Instances
 
-class table : public external {
+class Table : public Extern {
 public:
-  table() = delete;
-  ~table();
+  Table() = delete;
+  ~Table();
 
   using size_t = uint32_t;
 
-  static auto make(own<store*>&, const own<tabletype*>&, const own<ref*>&) -> own<table*>;
-  auto copy() const -> own<table*>;
+  static auto make(own<Store*>&, const own<TableType*>&, const own<Ref*>&) -> own<Table*>;
+  auto copy() const -> own<Table*>;
 
-  auto type() const -> own<tabletype*>;
-  auto get(size_t index) const -> own<ref*>;
-  void set(size_t index, const own<ref*>&);
+  auto type() const -> own<TableType*>;
+  auto get(size_t index) const -> own<Ref*>;
+  void set(size_t index, const own<Ref*>&);
   auto size() const -> size_t;
   auto grow(size_t delta) -> size_t;
 };
@@ -619,19 +619,19 @@ public:
 
 // Memory Instances
 
-class memory : public external {
+class Memory : public Extern {
 public:
-  memory() = delete;
-  ~memory();
+  Memory() = delete;
+  ~Memory();
 
-  static auto make(own<store*>&, const own<memtype*>&) -> own<memory*>;
-  auto copy() const -> own<memory*>;
+  static auto make(own<Store*>&, const own<MemoryType*>&) -> own<Memory*>;
+  auto copy() const -> own<Memory*>;
 
   using pages_t = uint32_t;
 
   static const size_t page_size = 0x10000;
 
-  auto type() const -> own<memtype*>;
+  auto type() const -> own<MemoryType*>;
   auto data() const -> byte_t*;
   auto data_size() const -> size_t;
   auto size() const -> pages_t;
@@ -641,15 +641,15 @@ public:
 
 // Module Instances
 
-class instance : public ref {
+class Instance : public Ref {
 public:
-  instance() = delete;
-  ~instance();
+  Instance() = delete;
+  ~Instance();
 
-  static auto make(own<store*>&, const own<module*>&, const vec<external*>&) -> own<instance*>;
-  auto copy() const -> own<instance*>;
+  static auto make(own<Store*>&, const own<Module*>&, const vec<Extern*>&) -> own<Instance*>;
+  auto copy() const -> own<Instance*>;
 
-  auto exports() const -> vec<external*>;
+  auto exports() const -> vec<Extern*>;
 };
 
 

--- a/src/wasm-bin.cc
+++ b/src/wasm-bin.cc
@@ -212,7 +212,7 @@ auto imports(const vec<byte_t>& binary, const vec<wasm::functype*>& types)
     auto name = bin::name(pos);
     own<externtype*> type;
     switch (*pos++) {
-      case 0x00: type = types[bin::u32(pos)]->clone(); break;
+      case 0x00: type = types[bin::u32(pos)]->copy(); break;
       case 0x01: type = bin::tabletype(pos); break;
       case 0x02: type = bin::memtype(pos); break;
       case 0x03: type = bin::globaltype(pos); break;
@@ -245,12 +245,12 @@ auto funcs(
   for (uint32_t i = 0; i < imports.size(); ++i) {
     auto& et = imports[i]->type();
     if (et->kind() == EXTERN_FUNC) {
-      v[j++] = et->func()->clone();
+      v[j++] = et->func()->copy();
     }
   }
   if (pos != nullptr) {
     for (; j < v.size(); ++j) {
-      v[j] = types[bin::u32(pos)]->clone();
+      v[j] = types[bin::u32(pos)]->copy();
     }
   }
   return v;
@@ -268,7 +268,7 @@ auto globals(const vec<byte_t>& binary, const vec<importtype*>& imports)
   for (uint32_t i = 0; i < imports.size(); ++i) {
     auto& et = imports[i]->type();
     if (et->kind() == EXTERN_GLOBAL) {
-      v[j++] = et->global()->clone();
+      v[j++] = et->global()->copy();
     }
   }
   if (pos != nullptr) {
@@ -291,7 +291,7 @@ auto tables(const vec<byte_t>& binary, const vec<importtype*>& imports)
   for (uint32_t i = 0; i < imports.size(); ++i) {
     auto& et = imports[i]->type();
     if (et->kind() == EXTERN_TABLE) {
-      v[j++] = et->table()->clone();
+      v[j++] = et->table()->copy();
     }
   }
   if (pos != nullptr) {
@@ -314,7 +314,7 @@ auto memories(const vec<byte_t>& binary, const vec<importtype*>& imports)
   for (uint32_t i = 0; i < imports.size(); ++i) {
     auto& et = imports[i]->type();
     if (et->kind() == EXTERN_MEMORY) {
-      v[j++] = et->memory()->clone();
+      v[j++] = et->memory()->copy();
     }
   }
   if (pos != nullptr) {
@@ -343,10 +343,10 @@ auto exports(const vec<byte_t>& binary,
       auto index = bin::u32(pos);
       own<externtype*> type;
       switch (tag) {
-        case 0x00: type = funcs[index]->clone(); break;
-        case 0x01: type = tables[index]->clone(); break;
-        case 0x02: type = memories[index]->clone(); break;
-        case 0x03: type = globals[index]->clone(); break;
+        case 0x00: type = funcs[index]->copy(); break;
+        case 0x01: type = tables[index]->copy(); break;
+        case 0x02: type = memories[index]->copy(); break;
+        case 0x03: type = globals[index]->copy(); break;
         default: assert(false);
       }
       exports[i] = exporttype::make(std::move(name), std::move(type));

--- a/src/wasm-bin.cc
+++ b/src/wasm-bin.cc
@@ -24,10 +24,10 @@ void u32_skip(const byte_t*& pos) {
 
 // Names
 
-auto name(const byte_t*& pos) -> wasm::name {
+auto name(const byte_t*& pos) -> Name {
   auto size = bin::u32(pos);
   auto start = pos;
-  auto name = name::make_uninitialized(size);
+  auto name = Name::make_uninitialized(size);
   memcpy(name.get(), start, size);
   pos += size;
   return name;
@@ -41,69 +41,69 @@ void name_skip(const byte_t*& pos) {
 
 // Types
 
-auto valtype(const byte_t*& pos) -> own<wasm::valtype*> {
+auto valtype(const byte_t*& pos) -> own<wasm::ValType*> {
   switch (*pos++) {
-    case 0x7f: return valtype::make(I32);
-    case 0x7e: return valtype::make(I64);
-    case 0x7d: return valtype::make(F32);
-    case 0x7c: return valtype::make(F64);
-    case 0x70: return valtype::make(FUNCREF);
-    case 0x6f: return valtype::make(ANYREF);
+    case 0x7f: return ValType::make(I32);
+    case 0x7e: return ValType::make(I64);
+    case 0x7d: return ValType::make(F32);
+    case 0x7c: return ValType::make(F64);
+    case 0x70: return ValType::make(FUNCREF);
+    case 0x6f: return ValType::make(ANYREF);
     default:
       // TODO(wasm+): support new value types
       assert(false);
   }
 }
 
-auto mut(const byte_t*& pos) -> wasm::mut {
+auto mutability(const byte_t*& pos) -> Mutability {
   return *pos++ ? VAR : CONST;
 }
 
-auto limits(const byte_t*& pos) -> limits {
+auto limits(const byte_t*& pos) -> Limits {
   auto tag = *pos++;
   auto min = bin::u32(pos);
   if ((tag & 0x01) == 0) {
-    return wasm::limits(min);
+    return Limits(min);
   } else {
     auto max = bin::u32(pos);
-    return wasm::limits(min, max);
+    return Limits(min, max);
   }
 }
 
-auto stacktype(const byte_t*& pos) -> vec<wasm::valtype*> {
+auto stacktype(const byte_t*& pos) -> vec<ValType*> {
   size_t size = bin::u32(pos);
-  auto v = vec<wasm::valtype*>::make_uninitialized(size);
+  auto v = vec<ValType*>::make_uninitialized(size);
   for (uint32_t i = 0; i < size; ++i) v[i] = bin::valtype(pos);
   return v;
 }
 
-auto functype(const byte_t*& pos) -> own<wasm::functype*> {
+auto functype(const byte_t*& pos) -> own<FuncType*> {
   assert(*pos == 0x60);
   ++pos;
   auto params = bin::stacktype(pos);
   auto results = bin::stacktype(pos);
-  return functype::make(std::move(params), std::move(results));
+  return FuncType::make(std::move(params), std::move(results));
 }
 
-auto globaltype(const byte_t*& pos) -> own<wasm::globaltype*> {
+auto globaltype(const byte_t*& pos) -> own<GlobalType*> {
   auto content = bin::valtype(pos);
-  auto mut = bin::mut(pos);
-  return globaltype::make(std::move(content), mut);
+  auto mutability = bin::mutability(pos);
+  return GlobalType::make(std::move(content), mutability);
 }
 
-auto tabletype(const byte_t*& pos) -> own<wasm::tabletype*> {
+auto tabletype(const byte_t*& pos) -> own<TableType*> {
   auto elem = bin::valtype(pos);
   auto limits = bin::limits(pos);
-  return tabletype::make(std::move(elem), limits);
+  return TableType::make(std::move(elem), limits);
 }
 
-auto memtype(const byte_t*& pos) -> own<wasm::memtype*> {
+auto memorytype(const byte_t*& pos) -> own<MemoryType*> {
   auto limits = bin::limits(pos);
-  return memtype::make(limits);
+  return MemoryType::make(limits);
 }
 
 
-void mut_skip(const byte_t*& pos) {
+void mutability_skip(const byte_t*& pos) {
   ++pos;
 }
 
@@ -120,7 +120,7 @@ void valtype_skip(const byte_t*& pos) {
 
 void globaltype_skip(const byte_t*& pos) {
   bin::valtype_skip(pos);
-  bin::mut_skip(pos);
+  bin::mutability_skip(pos);
 }
 
 void tabletype_skip(const byte_t*& pos) {
@@ -128,7 +128,7 @@ void tabletype_skip(const byte_t*& pos) {
   bin::limits_skip(pos);
 }
 
-void memtype_skip(const byte_t*& pos) {
+void memorytype_skip(const byte_t*& pos) {
   bin::limits_skip(pos);
 }
 
@@ -186,12 +186,12 @@ auto section(const vec<byte_t>& binary, bin::sec_t sec) -> const byte_t* {
 
 // Type section
 
-auto types(const vec<byte_t>& binary) -> vec<wasm::functype*> {
+auto types(const vec<byte_t>& binary) -> vec<FuncType*> {
   auto pos = bin::section(binary, SEC_TYPE);
-  if (pos == nullptr) return vec<wasm::functype*>::make();
+  if (pos == nullptr) return vec<FuncType*>::make();
   size_t size = bin::u32(pos);
   // TODO(wasm+): support new deftypes
-  auto v = vec<wasm::functype*>::make_uninitialized(size);
+  auto v = vec<FuncType*>::make_uninitialized(size);
   for (uint32_t i = 0; i < size; ++i) {
     v[i] = bin::functype(pos);
   }
@@ -201,29 +201,30 @@ auto types(const vec<byte_t>& binary) -> vec<wasm::functype*> {
 
 // Import section
 
-auto imports(const vec<byte_t>& binary, const vec<wasm::functype*>& types)
--> vec<importtype*> {
+auto imports(
+  const vec<byte_t>& binary, const vec<FuncType*>& types
+) -> vec<ImportType*> {
   auto pos = bin::section(binary, SEC_IMPORT);
-  if (pos == nullptr) return vec<importtype*>::make();
+  if (pos == nullptr) return vec<ImportType*>::make();
   size_t size = bin::u32(pos);
-  auto v = vec<importtype*>::make_uninitialized(size);
+  auto v = vec<ImportType*>::make_uninitialized(size);
   for (uint32_t i = 0; i < size; ++i) {
     auto module = bin::name(pos);
     auto name = bin::name(pos);
-    own<externtype*> type;
+    own<ExternType*> type;
     switch (*pos++) {
       case 0x00: type = types[bin::u32(pos)]->copy(); break;
       case 0x01: type = bin::tabletype(pos); break;
-      case 0x02: type = bin::memtype(pos); break;
+      case 0x02: type = bin::memorytype(pos); break;
       case 0x03: type = bin::globaltype(pos); break;
       default: assert(false);
     }
-    v[i] = importtype::make(std::move(module), std::move(name), std::move(type));
+    v[i] = ImportType::make(std::move(module), std::move(name), std::move(type));
   }
   return v;
 }
 
-auto count(const vec<importtype*>& imports, externkind kind) -> uint32_t {
+auto count(const vec<ImportType*>& imports, ExternKind kind) -> uint32_t {
   uint32_t n = 0;
   for (uint32_t i = 0; i < imports.size(); ++i) {
     if (imports[i]->type()->kind() == kind) ++n;
@@ -235,12 +236,12 @@ auto count(const vec<importtype*>& imports, externkind kind) -> uint32_t {
 // Function section
 
 auto funcs(
-  const vec<byte_t>& binary, const vec<importtype*>& imports,
-  const vec<wasm::functype*>& types
-) -> vec<wasm::functype*> {
+  const vec<byte_t>& binary,
+  const vec<ImportType*>& imports, const vec<FuncType*>& types
+) -> vec<FuncType*> {
   auto pos = bin::section(binary, SEC_FUNC);
   size_t size = pos != nullptr ? bin::u32(pos) : 0;
-  auto v = vec<wasm::functype*>::make_uninitialized(size + count(imports, EXTERN_FUNC));
+  auto v = vec<FuncType*>::make_uninitialized(size + count(imports, EXTERN_FUNC));
   size_t j = 0;
   for (uint32_t i = 0; i < imports.size(); ++i) {
     auto& et = imports[i]->type();
@@ -259,11 +260,12 @@ auto funcs(
 
 // Global section
 
-auto globals(const vec<byte_t>& binary, const vec<importtype*>& imports)
--> vec<wasm::globaltype*> {
+auto globals(
+  const vec<byte_t>& binary, const vec<ImportType*>& imports
+) -> vec<GlobalType*> {
   auto pos = bin::section(binary, SEC_GLOBAL);
   size_t size = pos != nullptr ? bin::u32(pos) : 0;
-  auto v = vec<wasm::globaltype*>::make_uninitialized(size + count(imports, EXTERN_GLOBAL));
+  auto v = vec<GlobalType*>::make_uninitialized(size + count(imports, EXTERN_GLOBAL));
   size_t j = 0;
   for (uint32_t i = 0; i < imports.size(); ++i) {
     auto& et = imports[i]->type();
@@ -282,11 +284,12 @@ auto globals(const vec<byte_t>& binary, const vec<importtype*>& imports)
 
 // Table section
 
-auto tables(const vec<byte_t>& binary, const vec<importtype*>& imports)
--> vec<wasm::tabletype*> {
+auto tables(
+  const vec<byte_t>& binary, const vec<ImportType*>& imports
+) -> vec<TableType*> {
   auto pos = bin::section(binary, SEC_TABLE);
   size_t size = pos != nullptr ? bin::u32(pos) : 0;
-  auto v = vec<wasm::tabletype*>::make_uninitialized(size + count(imports, EXTERN_TABLE));
+  auto v = vec<TableType*>::make_uninitialized(size + count(imports, EXTERN_TABLE));
   size_t j = 0;
   for (uint32_t i = 0; i < imports.size(); ++i) {
     auto& et = imports[i]->type();
@@ -305,11 +308,12 @@ auto tables(const vec<byte_t>& binary, const vec<importtype*>& imports)
 
 // Memory section
 
-auto memories(const vec<byte_t>& binary, const vec<importtype*>& imports)
--> vec<wasm::memtype*> {
+auto memories(
+  const vec<byte_t>& binary, const vec<ImportType*>& imports
+) -> vec<MemoryType*> {
   auto pos = bin::section(binary, SEC_MEMORY);
   size_t size = pos != nullptr ? bin::u32(pos) : 0;
-  auto v = vec<wasm::memtype*>::make_uninitialized(size + count(imports, EXTERN_MEMORY));
+  auto v = vec<MemoryType*>::make_uninitialized(size + count(imports, EXTERN_MEMORY));
   size_t j = 0;
   for (uint32_t i = 0; i < imports.size(); ++i) {
     auto& et = imports[i]->type();
@@ -319,7 +323,7 @@ auto memories(const vec<byte_t>& binary, const vec<importtype*>& imports)
   }
   if (pos != nullptr) {
     for (; j < v.size(); ++j) {
-      v[j] = bin::memtype(pos);
+      v[j] = bin::memorytype(pos);
     }
   }
   return v;
@@ -329,19 +333,19 @@ auto memories(const vec<byte_t>& binary, const vec<importtype*>& imports)
 // Export section
 
 auto exports(const vec<byte_t>& binary,
-  const vec<wasm::functype*>& funcs, const vec<wasm::globaltype*>& globals,
-  const vec<wasm::tabletype*>& tables, const vec<wasm::memtype*>& memories
-) -> vec<exporttype*> {
-  auto exports = vec<exporttype*>::make();
+  const vec<FuncType*>& funcs, const vec<GlobalType*>& globals,
+  const vec<TableType*>& tables, const vec<MemoryType*>& memories
+) -> vec<ExportType*> {
+  auto exports = vec<ExportType*>::make();
   auto pos = bin::section(binary, SEC_EXPORT);
   if (pos != nullptr) {
     size_t size = bin::u32(pos);
-    exports = vec<exporttype*>::make_uninitialized(size);
+    exports = vec<ExportType*>::make_uninitialized(size);
     for (uint32_t i = 0; i < size; ++i) {
       auto name = bin::name(pos);
       auto tag = *pos++;
       auto index = bin::u32(pos);
-      own<externtype*> type;
+      own<ExternType*> type;
       switch (tag) {
         case 0x00: type = funcs[index]->copy(); break;
         case 0x01: type = tables[index]->copy(); break;
@@ -349,14 +353,15 @@ auto exports(const vec<byte_t>& binary,
         case 0x03: type = globals[index]->copy(); break;
         default: assert(false);
       }
-      exports[i] = exporttype::make(std::move(name), std::move(type));
+      exports[i] = ExportType::make(std::move(name), std::move(type));
     }
   }
   return exports;
 }
 
-auto imports_exports(const vec<byte_t>& binary)
--> std::tuple<vec<importtype*>, vec<exporttype*>> {
+auto imports_exports(
+  const vec<byte_t>& binary
+) -> std::tuple<vec<ImportType*>, vec<ExportType*>> {
   auto types = bin::types(binary);
   auto imports = bin::imports(binary, types);
   auto funcs = bin::funcs(binary, imports, types);

--- a/src/wasm-bin.hh
+++ b/src/wasm-bin.hh
@@ -8,7 +8,7 @@ namespace wasm {
 namespace bin {
 
 auto imports_exports(const vec<byte_t>& binary) ->
-  std::tuple<vec<importtype*>, vec<exporttype*>>;
+  std::tuple<vec<ImportType*>, vec<ExportType*>>;
 
 }  // namespace bin
 }  // namespace wasm

--- a/src/wasm-c.cc
+++ b/src/wasm-c.cc
@@ -32,94 +32,94 @@ struct borrowed_vec {
 }  // extern "C++"
 
 
-#define WASM_DEFINE_OWN(name) \
-  struct wasm_##name##_t : wasm::name {}; \
+#define WASM_DEFINE_OWN(name, Name) \
+  struct wasm_##name##_t : Name {}; \
   \
   void wasm_##name##_delete(wasm_##name##_t* x) { \
     delete x; \
   } \
   \
-  extern "C++" inline auto hide(wasm::name* x) -> wasm_##name##_t* { \
+  extern "C++" inline auto hide(Name* x) -> wasm_##name##_t* { \
     return static_cast<wasm_##name##_t*>(x); \
   } \
-  extern "C++" inline auto hide(const wasm::name* x) -> const wasm_##name##_t* { \
+  extern "C++" inline auto hide(const Name* x) -> const wasm_##name##_t* { \
     return static_cast<const wasm_##name##_t*>(x); \
   } \
-  extern "C++" inline auto reveal(wasm_##name##_t* x) -> wasm::name* { \
+  extern "C++" inline auto reveal(wasm_##name##_t* x) -> Name* { \
     return x; \
   } \
-  extern "C++" inline auto reveal(const wasm_##name##_t* x) -> const wasm::name* { \
+  extern "C++" inline auto reveal(const wasm_##name##_t* x) -> const Name* { \
     return x; \
   } \
-  extern "C++" inline auto get(own<wasm::name*>& x) -> wasm_##name##_t* { \
+  extern "C++" inline auto get(own<Name*>& x) -> wasm_##name##_t* { \
     return hide(x.get()); \
   } \
-  extern "C++" inline auto get(const own<wasm::name*>& x) -> const wasm_##name##_t* { \
+  extern "C++" inline auto get(const own<Name*>& x) -> const wasm_##name##_t* { \
     return hide(x.get()); \
   } \
-  extern "C++" inline auto release(own<wasm::name*>&& x) -> wasm_##name##_t* { \
+  extern "C++" inline auto release(own<Name*>&& x) -> wasm_##name##_t* { \
     return hide(x.release()); \
   } \
-  extern "C++" inline auto adopt(wasm_##name##_t* x) -> own<wasm::name*> { \
+  extern "C++" inline auto adopt(wasm_##name##_t* x) -> own<Name*> { \
     return make_own(x); \
   } \
-  extern "C++" inline auto borrow(wasm_##name##_t* x) -> borrowed<name*> { \
-    return borrowed<name*>(x); \
+  extern "C++" inline auto borrow(wasm_##name##_t* x) -> borrowed<Name*> { \
+    return borrowed<Name*>(x); \
   } \
-  extern "C++" inline auto borrow(const wasm_##name##_t* x) -> const borrowed<name*> { \
+  extern "C++" inline auto borrow(const wasm_##name##_t* x) -> const borrowed<Name*> { \
     /* TODO: fishy? */ \
-    return borrowed<name*>(const_cast<wasm_##name##_t*>(x)); \
+    return borrowed<Name*>(const_cast<wasm_##name##_t*>(x)); \
   }
 
 
 // Vectors
 
-#define WASM_DEFINE_VEC_BASE(name, ptr_or_none) \
-  extern "C++" inline auto hide(name ptr_or_none* v) -> wasm_##name##_t ptr_or_none* { \
-    static_assert(sizeof(wasm_##name##_t ptr_or_none) == sizeof(name ptr_or_none), "C/C++ incompatibility"); \
+#define WASM_DEFINE_VEC_BASE(name, Name, ptr_or_none) \
+  extern "C++" inline auto hide(Name ptr_or_none* v) -> wasm_##name##_t ptr_or_none* { \
+    static_assert(sizeof(wasm_##name##_t ptr_or_none) == sizeof(Name ptr_or_none), "C/C++ incompatibility"); \
     return reinterpret_cast<wasm_##name##_t ptr_or_none*>(v); \
   } \
-  extern "C++" inline auto hide(name ptr_or_none const* v) -> wasm_##name##_t ptr_or_none const* { \
-    static_assert(sizeof(wasm_##name##_t ptr_or_none) == sizeof(name ptr_or_none), "C/C++ incompatibility"); \
+  extern "C++" inline auto hide(Name ptr_or_none const* v) -> wasm_##name##_t ptr_or_none const* { \
+    static_assert(sizeof(wasm_##name##_t ptr_or_none) == sizeof(Name ptr_or_none), "C/C++ incompatibility"); \
     return reinterpret_cast<wasm_##name##_t ptr_or_none const*>(v); \
   } \
-  extern "C++" inline auto reveal(wasm_##name##_t ptr_or_none* v) -> name ptr_or_none* { \
-    static_assert(sizeof(wasm_##name##_t ptr_or_none) == sizeof(name ptr_or_none), "C/C++ incompatibility"); \
-    return reinterpret_cast<name ptr_or_none*>(v); \
+  extern "C++" inline auto reveal(wasm_##name##_t ptr_or_none* v) -> Name ptr_or_none* { \
+    static_assert(sizeof(wasm_##name##_t ptr_or_none) == sizeof(Name ptr_or_none), "C/C++ incompatibility"); \
+    return reinterpret_cast<Name ptr_or_none*>(v); \
   } \
-  extern "C++" inline auto reveal(wasm_##name##_t ptr_or_none const* v) -> name ptr_or_none const* { \
-    static_assert(sizeof(wasm_##name##_t ptr_or_none) == sizeof(name ptr_or_none), "C/C++ incompatibility"); \
-    return reinterpret_cast<name ptr_or_none const*>(v); \
+  extern "C++" inline auto reveal(wasm_##name##_t ptr_or_none const* v) -> Name ptr_or_none const* { \
+    static_assert(sizeof(wasm_##name##_t ptr_or_none) == sizeof(Name ptr_or_none), "C/C++ incompatibility"); \
+    return reinterpret_cast<Name ptr_or_none const*>(v); \
   } \
-  extern "C++" inline auto get(wasm::vec<name ptr_or_none>& v) -> wasm_##name##_vec_t { \
+  extern "C++" inline auto get(vec<Name ptr_or_none>& v) -> wasm_##name##_vec_t { \
     return wasm_##name##_vec(v.size(), hide(v.get())); \
   } \
-  extern "C++" inline auto get(const wasm::vec<name ptr_or_none>& v) -> const wasm_##name##_vec_t { \
+  extern "C++" inline auto get(const vec<Name ptr_or_none>& v) -> const wasm_##name##_vec_t { \
     return wasm_##name##_vec(v.size(), const_cast<wasm_##name##_t ptr_or_none*>(hide(v.get()))); \
   } \
-  extern "C++" inline auto release(wasm::vec<name ptr_or_none>&& v) -> wasm_##name##_vec_t { \
+  extern "C++" inline auto release(vec<Name ptr_or_none>&& v) -> wasm_##name##_vec_t { \
     return wasm_##name##_vec(v.size(), hide(v.release())); \
   } \
-  extern "C++" inline auto adopt(wasm_##name##_vec_t v) -> wasm::vec<name ptr_or_none> { \
-    return wasm::vec<name ptr_or_none>::adopt(v.size, reveal(v.data)); \
+  extern "C++" inline auto adopt(wasm_##name##_vec_t v) -> vec<Name ptr_or_none> { \
+    return vec<Name ptr_or_none>::adopt(v.size, reveal(v.data)); \
   } \
-  extern "C++" inline auto borrow(wasm_##name##_vec_t v) -> borrowed_vec<name ptr_or_none> { \
-    return borrowed_vec<name ptr_or_none>(wasm::vec<name ptr_or_none>::adopt(v.size, reveal(v.data))); \
+  extern "C++" inline auto borrow(wasm_##name##_vec_t v) -> borrowed_vec<Name ptr_or_none> { \
+    return borrowed_vec<Name ptr_or_none>(vec<Name ptr_or_none>::adopt(v.size, reveal(v.data))); \
   } \
   \
   wasm_##name##_vec_t wasm_##name##_vec_new_uninitialized(size_t size) { \
-    return release(wasm::vec<name ptr_or_none>::make_uninitialized(size)); \
+    return release(vec<Name ptr_or_none>::make_uninitialized(size)); \
   } \
   wasm_##name##_vec_t wasm_##name##_vec_new_empty() { \
     return wasm_##name##_vec_new_uninitialized(0); \
   }
 
 // Vectors with no ownership management of elements
-#define WASM_DEFINE_VEC_PLAIN(name, ptr_or_none) \
-  WASM_DEFINE_VEC_BASE(name, ptr_or_none) \
+#define WASM_DEFINE_VEC_PLAIN(name, Name, ptr_or_none) \
+  WASM_DEFINE_VEC_BASE(name, Name, ptr_or_none) \
   \
   wasm_##name##_vec_t wasm_##name##_vec_new(size_t size, wasm_##name##_t ptr_or_none const data[]) { \
-    auto v2 = wasm::vec<name ptr_or_none>::make_uninitialized(size); \
+    auto v2 = vec<Name ptr_or_none>::make_uninitialized(size); \
     if (v2.size() != 0) memcpy(v2.get(), data, size * sizeof(wasm_##name##_t ptr_or_none)); \
     return release(std::move(v2)); \
   } \
@@ -133,11 +133,11 @@ struct borrowed_vec {
   }
 
 // Vectors who own their elements
-#define WASM_DEFINE_VEC(name, ptr_or_none) \
-  WASM_DEFINE_VEC_BASE(name, ptr_or_none) \
+#define WASM_DEFINE_VEC(name, Name, ptr_or_none) \
+  WASM_DEFINE_VEC_BASE(name, Name, ptr_or_none) \
   \
   wasm_##name##_vec_t wasm_##name##_vec_new(size_t size, wasm_##name##_t ptr_or_none const data[]) { \
-    auto v2 = wasm::vec<name ptr_or_none>::make_uninitialized(size); \
+    auto v2 = vec<Name ptr_or_none>::make_uninitialized(size); \
     for (size_t i = 0; i < v2.size(); ++i) { \
       v2[i] = adopt(data[i]); \
     } \
@@ -145,7 +145,7 @@ struct borrowed_vec {
   } \
   \
   wasm_##name##_vec_t wasm_##name##_vec_copy(wasm_##name##_vec_t v) { \
-    auto v2 = wasm::vec<name ptr_or_none>::make_uninitialized(v.size); \
+    auto v2 = vec<Name ptr_or_none>::make_uninitialized(v.size); \
     for (size_t i = 0; i < v2.size(); ++i) { \
       v2[i] = adopt(wasm_##name##_copy(v.data[i])); \
     } \
@@ -170,7 +170,7 @@ inline auto is_empty(T* p) -> bool { return !p; }
 // Byte vectors
 
 using byte = byte_t;
-WASM_DEFINE_VEC_PLAIN(byte, )
+WASM_DEFINE_VEC_PLAIN(byte, byte, )
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -178,35 +178,35 @@ WASM_DEFINE_VEC_PLAIN(byte, )
 
 // Configuration
 
-WASM_DEFINE_OWN(config)
+WASM_DEFINE_OWN(config, Config)
 
 wasm_config_t* wasm_config_new() {
-  return release(config::make());
+  return release(Config::make());
 }
 
 
 // Engine
 
-WASM_DEFINE_OWN(engine)
+WASM_DEFINE_OWN(engine, Engine)
 
 wasm_engine_t* wasm_engine_new(int argc, const char *const argv[]) {
-  return release(engine::make(argc, argv));
+  return release(Engine::make(argc, argv));
 }
 
 wasm_engine_t* wasm_engine_new_with_config(
   int argc, const char *const argv[], wasm_config_t* config
 ) {
-  return release(engine::make(argc, argv, adopt(config)));
+  return release(Engine::make(argc, argv, adopt(config)));
 }
 
 
 // Stores
 
-WASM_DEFINE_OWN(store)
+WASM_DEFINE_OWN(store, Store)
 
 wasm_store_t* wasm_store_new(wasm_engine_t* engine) {
   auto engine_ = borrow(engine);
-  return release(store::make(engine_.it));
+  return release(Store::make(engine_.it));
 };
 
 
@@ -215,48 +215,48 @@ wasm_store_t* wasm_store_new(wasm_engine_t* engine) {
 
 // Type attributes
 
-extern "C++" inline auto hide(wasm::mut mut) -> wasm_mut_t {
-  return static_cast<wasm_mut_t>(mut);
+extern "C++" inline auto hide(Mutability mutability) -> wasm_mutability_t {
+  return static_cast<wasm_mutability_t>(mutability);
 }
 
-extern "C++" inline auto reveal(wasm_mut_t mut) -> wasm::mut {
-  return static_cast<wasm::mut>(mut);
+extern "C++" inline auto reveal(wasm_mutability_t mutability) -> Mutability {
+  return static_cast<Mutability>(mutability);
 }
 
 
-extern "C++" inline auto hide(wasm::limits limits) -> wasm_limits_t {
+extern "C++" inline auto hide(Limits limits) -> wasm_limits_t {
   return wasm_limits(limits.min, limits.max);
 }
 
-extern "C++" inline auto reveal(wasm_limits_t limits) -> wasm::limits {
-  return wasm::limits(limits.min, limits.max);
+extern "C++" inline auto reveal(wasm_limits_t limits) -> Limits {
+  return Limits(limits.min, limits.max);
 }
 
 
-extern "C++" inline auto hide(wasm::valkind kind) -> wasm_valkind_t {
+extern "C++" inline auto hide(ValKind kind) -> wasm_valkind_t {
   return static_cast<wasm_valkind_t>(kind);
 }
 
-extern "C++" inline auto reveal(wasm_valkind_t kind) -> wasm::valkind {
-  return static_cast<wasm::valkind>(kind);
+extern "C++" inline auto reveal(wasm_valkind_t kind) -> ValKind {
+  return static_cast<ValKind>(kind);
 }
 
 
-extern "C++" inline auto hide(wasm::externkind kind) -> wasm_externkind_t {
+extern "C++" inline auto hide(ExternKind kind) -> wasm_externkind_t {
   return static_cast<wasm_externkind_t>(kind);
 }
 
-extern "C++" inline auto reveal(wasm_externkind_t kind) -> wasm::externkind {
-  return static_cast<wasm::externkind>(kind);
+extern "C++" inline auto reveal(wasm_externkind_t kind) -> ExternKind {
+  return static_cast<ExternKind>(kind);
 }
 
 
 
 // Generic
 
-#define WASM_DEFINE_TYPE(name) \
-  WASM_DEFINE_OWN(name) \
-  WASM_DEFINE_VEC(name, *) \
+#define WASM_DEFINE_TYPE(name, Name) \
+  WASM_DEFINE_OWN(name, Name) \
+  WASM_DEFINE_VEC(name, Name, *) \
   \
   wasm_##name##_t* wasm_##name##_copy(wasm_##name##_t* t) { \
     return release(t->copy()); \
@@ -265,10 +265,10 @@ extern "C++" inline auto reveal(wasm_externkind_t kind) -> wasm::externkind {
 
 // Value Types
 
-WASM_DEFINE_TYPE(valtype)
+WASM_DEFINE_TYPE(valtype, ValType)
 
 wasm_valtype_t* wasm_valtype_new(wasm_valkind_t k) {
-  return release(valtype::make(reveal(k)));
+  return release(ValType::make(reveal(k)));
 }
 
 wasm_valkind_t wasm_valtype_kind(wasm_valtype_t* t) {
@@ -278,10 +278,10 @@ wasm_valkind_t wasm_valtype_kind(wasm_valtype_t* t) {
 
 // Function Types
 
-WASM_DEFINE_TYPE(functype)
+WASM_DEFINE_TYPE(functype, FuncType)
 
 wasm_functype_t* wasm_functype_new(wasm_valtype_vec_t params, wasm_valtype_vec_t results) {
-  return release(functype::make(adopt(params), adopt(results)));
+  return release(FuncType::make(adopt(params), adopt(results)));
 }
 
 const wasm_valtype_vec_t wasm_functype_params(const wasm_functype_t* ft) {
@@ -295,27 +295,27 @@ const wasm_valtype_vec_t wasm_functype_results(const wasm_functype_t* ft) {
 
 // Global Types
 
-WASM_DEFINE_TYPE(globaltype)
+WASM_DEFINE_TYPE(globaltype, GlobalType)
 
-wasm_globaltype_t* wasm_globaltype_new(wasm_valtype_t* content, wasm_mut_t mut) {
-  return release(globaltype::make(adopt(content), reveal(mut)));
+wasm_globaltype_t* wasm_globaltype_new(wasm_valtype_t* content, wasm_mutability_t mutability) {
+  return release(GlobalType::make(adopt(content), reveal(mutability)));
 }
 
 const wasm_valtype_t* wasm_globaltype_content(const wasm_globaltype_t* gt) {
   return get(gt->content());
 }
 
-wasm_mut_t wasm_globaltype_mut(const wasm_globaltype_t* gt) {
-  return hide(gt->mut());
+wasm_mutability_t wasm_globaltype_mutability(const wasm_globaltype_t* gt) {
+  return hide(gt->mutability());
 }
 
 
 // Table Types
 
-WASM_DEFINE_TYPE(tabletype)
+WASM_DEFINE_TYPE(tabletype, TableType)
 
 wasm_tabletype_t* wasm_tabletype_new(wasm_valtype_t* elem, wasm_limits_t limits) {
-  return release(tabletype::make(adopt(elem), reveal(limits)));
+  return release(TableType::make(adopt(elem), reveal(limits)));
 }
 
 const wasm_valtype_t* wasm_tabletype_elem(const wasm_tabletype_t* tt) {
@@ -329,45 +329,45 @@ wasm_limits_t wasm_tabletype_limits(const wasm_tabletype_t* tt) {
 
 // Memory Types
 
-WASM_DEFINE_TYPE(memtype)
+WASM_DEFINE_TYPE(memorytype, MemoryType)
 
-wasm_memtype_t* wasm_memtype_new(wasm_limits_t limits) {
-  return release(memtype::make(reveal(limits)));
+wasm_memorytype_t* wasm_memorytype_new(wasm_limits_t limits) {
+  return release(MemoryType::make(reveal(limits)));
 }
 
-wasm_limits_t wasm_memtype_limits(const wasm_memtype_t* mt) {
+wasm_limits_t wasm_memorytype_limits(const wasm_memorytype_t* mt) {
   return hide(mt->limits());
 }
 
 
 // Extern Types
 
-WASM_DEFINE_TYPE(externtype)
+WASM_DEFINE_TYPE(externtype, ExternType)
 
 const wasm_externtype_t* wasm_functype_as_externtype(const wasm_functype_t* ft) {
-  return hide(static_cast<const externtype*>(ft));
+  return hide(static_cast<const ExternType*>(ft));
 }
 const wasm_externtype_t* wasm_globaltype_as_externtype(const wasm_globaltype_t* gt) {
-  return hide(static_cast<const externtype*>(gt));
+  return hide(static_cast<const ExternType*>(gt));
 }
 const wasm_externtype_t* wasm_tabletype_as_externtype(const wasm_tabletype_t* tt) {
-  return hide(static_cast<const externtype*>(tt));
+  return hide(static_cast<const ExternType*>(tt));
 }
-const wasm_externtype_t* wasm_memtype_as_externtype(const wasm_memtype_t* mt) {
-  return hide(static_cast<const externtype*>(mt));
+const wasm_externtype_t* wasm_memorytype_as_externtype(const wasm_memorytype_t* mt) {
+  return hide(static_cast<const ExternType*>(mt));
 }
 
 const wasm_functype_t* wasm_externtype_as_functype(const wasm_externtype_t* et) {
-  return et->kind() == EXTERN_FUNC ? hide(static_cast<const functype*>(reveal(et))) : nullptr;
+  return et->kind() == EXTERN_FUNC ? hide(static_cast<const FuncType*>(reveal(et))) : nullptr;
 }
 const wasm_globaltype_t* wasm_externtype_as_globaltype(const wasm_externtype_t* et) {
-  return et->kind() == EXTERN_GLOBAL ? hide(static_cast<const globaltype*>(reveal(et))) : nullptr;
+  return et->kind() == EXTERN_GLOBAL ? hide(static_cast<const GlobalType*>(reveal(et))) : nullptr;
 }
 const wasm_tabletype_t* wasm_externtype_as_tabletype(const wasm_externtype_t* et) {
-  return et->kind() == EXTERN_TABLE ? hide(static_cast<const tabletype*>(reveal(et))) : nullptr;
+  return et->kind() == EXTERN_TABLE ? hide(static_cast<const TableType*>(reveal(et))) : nullptr;
 }
-const wasm_memtype_t* wasm_externtype_as_memtype(const wasm_externtype_t* et) {
-  return et->kind() == EXTERN_MEMORY ? hide(static_cast<const memtype*>(reveal(et))) : nullptr;
+const wasm_memorytype_t* wasm_externtype_as_memorytype(const wasm_externtype_t* et) {
+  return et->kind() == EXTERN_MEMORY ? hide(static_cast<const MemoryType*>(reveal(et))) : nullptr;
 }
 
 wasm_externkind_t wasm_externtype_kind(const wasm_externtype_t* et) {
@@ -377,10 +377,10 @@ wasm_externkind_t wasm_externtype_kind(const wasm_externtype_t* et) {
 
 // Import Types
 
-WASM_DEFINE_TYPE(importtype)
+WASM_DEFINE_TYPE(importtype, ImportType)
 
 wasm_importtype_t* wasm_importtype_new(wasm_name_t module, wasm_name_t name, wasm_externtype_t* type) {
-  return release(importtype::make(adopt(module), adopt(name), adopt(type)));
+  return release(ImportType::make(adopt(module), adopt(name), adopt(type)));
 }
 
 const wasm_name_t wasm_importtype_module(const wasm_importtype_t* it) {
@@ -398,10 +398,10 @@ const wasm_externtype_t* wasm_importtype_type(const wasm_importtype_t* it) {
 
 // Export Types
 
-WASM_DEFINE_TYPE(exporttype)
+WASM_DEFINE_TYPE(exporttype, ExportType)
 
 wasm_exporttype_t* wasm_exporttype_new(wasm_name_t name, wasm_externtype_t* type) {
-  return release(exporttype::make(adopt(name), adopt(type)));
+  return release(ExportType::make(adopt(name), adopt(type)));
 }
 
 const wasm_name_t wasm_exporttype_name(const wasm_exporttype_t* et) {
@@ -418,8 +418,8 @@ const wasm_externtype_t* wasm_exporttype_type(const wasm_exporttype_t* et) {
 
 // References
 
-#define WASM_DEFINE_REF_BASE(name) \
-  WASM_DEFINE_OWN(name) \
+#define WASM_DEFINE_REF_BASE(name, Name) \
+  WASM_DEFINE_OWN(name, Name) \
   \
   wasm_##name##_t* wasm_##name##_copy(const wasm_##name##_t* t) { \
     return release(t->copy()); \
@@ -437,18 +437,18 @@ const wasm_externtype_t* wasm_exporttype_type(const wasm_exporttype_t* et) {
     r->set_host_info(info, finalizer); \
   }
 
-#define WASM_DEFINE_REF(name) \
-  WASM_DEFINE_REF_BASE(name) \
+#define WASM_DEFINE_REF(name, Name) \
+  WASM_DEFINE_REF_BASE(name, Name) \
   \
   const wasm_ref_t* wasm_##name##_as_ref(const wasm_##name##_t* r) { \
-    return hide(static_cast<const ref*>(reveal(r))); \
+    return hide(static_cast<const Ref*>(reveal(r))); \
   } \
   const wasm_##name##_t* wasm_ref_as_##name(const wasm_ref_t* r) { \
-    return hide(static_cast<const name*>(reveal(r))); \
+    return hide(static_cast<const Name*>(reveal(r))); \
   }
 
 
-WASM_DEFINE_REF_BASE(ref)
+WASM_DEFINE_REF_BASE(ref, Ref)
 
 
 // Values
@@ -459,7 +459,7 @@ inline auto is_empty(wasm_val_t v) -> bool {
  return !is_ref(reveal(v.kind)) || !v.ref;
 }
 
-inline auto hide(wasm::val v) -> wasm_val_t {
+inline auto hide(Val v) -> wasm_val_t {
   wasm_val_t v2 = { hide(v.kind()) };
   switch (v.kind()) {
     case I32: v2.i32 = v.i32(); break;
@@ -473,7 +473,7 @@ inline auto hide(wasm::val v) -> wasm_val_t {
   return v2;
 }
 
-inline auto release(wasm::val v) -> wasm_val_t {
+inline auto release(Val v) -> wasm_val_t {
   wasm_val_t v2 = { hide(v.kind()) };
   switch (v.kind()) {
     case I32: v2.i32 = v.i32(); break;
@@ -487,34 +487,34 @@ inline auto release(wasm::val v) -> wasm_val_t {
   return v2;
 }
 
-inline auto adopt(wasm_val_t v) -> wasm::val {
+inline auto adopt(wasm_val_t v) -> Val {
   switch (reveal(v.kind)) {
-    case I32: return val(v.i32);
-    case I64: return val(v.i64);
-    case F32: return val(v.f32);
-    case F64: return val(v.f64);
+    case I32: return Val(v.i32);
+    case I64: return Val(v.i64);
+    case F32: return Val(v.f32);
+    case F64: return Val(v.f64);
     case ANYREF:
-    case FUNCREF: return val(adopt(v.ref));
+    case FUNCREF: return Val(adopt(v.ref));
     default: assert(false);
   }
 }
 
 struct borrowed_val {
-  val it;
-  borrowed_val(val&& v) : it(std::move(v)) {}
+  Val it;
+  borrowed_val(Val&& v) : it(std::move(v)) {}
   borrowed_val(borrowed_val&& that) : it(std::move(that.it)) {}
   ~borrowed_val() { it.release_ref(); }
 };
 
 inline auto borrow(wasm_val_t v) -> borrowed_val {
-  val v2;
+  Val v2;
   switch (reveal(v.kind)) {
-    case I32: v2 = val(v.i32); break;
-    case I64: v2 = val(v.i64); break;
-    case F32: v2 = val(v.f32); break;
-    case F64: v2 = val(v.f64); break;
+    case I32: v2 = Val(v.i32); break;
+    case I64: v2 = Val(v.i64); break;
+    case F32: v2 = Val(v.f32); break;
+    case F64: v2 = Val(v.f64); break;
     case ANYREF:
-    case FUNCREF: v2 = val(adopt(v.ref)); break;
+    case FUNCREF: v2 = Val(adopt(v.ref)); break;
     default: assert(false);
   }
   return borrowed_val(std::move(v2));
@@ -522,7 +522,7 @@ inline auto borrow(wasm_val_t v) -> borrowed_val {
 
 }  // extern "C++"
 
-WASM_DEFINE_VEC(val, )
+WASM_DEFINE_VEC(val, Val, )
 
 
 void wasm_val_delete(wasm_val_t v) {
@@ -544,18 +544,18 @@ wasm_val_t wasm_val_copy(wasm_val_t v) {
 // Modules
 
 
-WASM_DEFINE_REF(module)
+WASM_DEFINE_REF(module, Module)
 
 bool wasm_module_validate(wasm_store_t* store, wasm_byte_vec_t binary) {
   auto store_ = borrow(store);
   auto binary_ = borrow(binary);
-  return module::validate(store_.it, binary_.it);
+  return Module::validate(store_.it, binary_.it);
 }
 
 wasm_module_t* wasm_module_new(wasm_store_t* store, wasm_byte_vec_t binary) {
   auto store_ = borrow(store);
   auto binary_ = borrow(binary);
-  return release(module::make(store_.it, binary_.it));
+  return release(Module::make(store_.it, binary_.it));
 }
 
 
@@ -573,27 +573,27 @@ wasm_byte_vec_t wasm_module_serialize(const wasm_module_t* module) {
 
 wasm_module_t* wasm_module_deserialize(wasm_byte_vec_t binary) {
   auto binary_ = borrow(binary);
-  return release(module::deserialize(binary_.it));
+  return release(Module::deserialize(binary_.it));
 }
 
 
-// Host Objects
+// Foreign Objects
 
-WASM_DEFINE_REF(hostobj)
+WASM_DEFINE_REF(foreign, Foreign)
 
-wasm_hostobj_t* wasm_hostobj_new(wasm_store_t* store) {
+wasm_foreign_t* wasm_foreign_new(wasm_store_t* store) {
   auto store_ = borrow(store);
-  return release(hostobj::make(store_.it));
+  return release(Foreign::make(store_.it));
 }
 
 
 // Function Instances
 
-WASM_DEFINE_REF(func)
+WASM_DEFINE_REF(func, Func)
 
 extern "C++" {
 
-vec<val> wasm_callback(void* env, const vec<val>& args) {
+vec<Val> wasm_callback(void* env, const vec<Val>& args) {
   auto f = reinterpret_cast<wasm_func_callback_t>(env);
   return adopt(f(get(args)));
 }
@@ -601,7 +601,7 @@ vec<val> wasm_callback(void* env, const vec<val>& args) {
 using wasm_callback_env =
   std::tuple<wasm_func_callback_with_env_t, void*, void (*)(void*)>;
 
-vec<val> wasm_callback_with_env(void* env, const vec<val>& args) {
+vec<Val> wasm_callback_with_env(void* env, const vec<Val>& args) {
   auto t = *static_cast<wasm_callback_env*>(env);
   return adopt(std::get<0>(t)(std::get<1>(t), get(args)));
 }
@@ -617,14 +617,14 @@ void wasm_callback_env_finalizer(void* env) {
 wasm_func_t* wasm_func_new(wasm_store_t* store, const wasm_functype_t* type, wasm_func_callback_t callback) {
   auto store_ = borrow(store);
   auto type_ = borrow(type);
-  return release(func::make(store_.it, type_.it, wasm_callback, reinterpret_cast<void*>(callback)));
+  return release(Func::make(store_.it, type_.it, wasm_callback, reinterpret_cast<void*>(callback)));
 }
 
 wasm_func_t *wasm_func_new_with_env(wasm_store_t* store, const wasm_functype_t* type, wasm_func_callback_with_env_t callback, wasm_ref_t *env, void (*finalizer)(void*)) {
   auto store_ = borrow(store);
   auto type_ = borrow(type);
   auto env2 = new wasm_callback_env(callback, env);
-  return release(func::make(store_.it, type_.it, wasm_callback_with_env, env2));
+  return release(Func::make(store_.it, type_.it, wasm_callback_with_env, env2));
 }
 
 wasm_functype_t* wasm_func_type(const wasm_func_t* func) {
@@ -640,13 +640,13 @@ wasm_val_vec_t wasm_func_call(const wasm_func_t* func, wasm_val_vec_t args) {
 
 // Global Instances
 
-WASM_DEFINE_REF(global)
+WASM_DEFINE_REF(global, Global)
 
 wasm_global_t* wasm_global_new(wasm_store_t* store, const wasm_globaltype_t* type, wasm_val_t val) {
   auto store_ = borrow(store);
   auto type_ = borrow(type);
   auto val_ = borrow(val);
-  return release(global::make(store_.it, type_.it, val_.it));
+  return release(Global::make(store_.it, type_.it, val_.it));
 }
 
 wasm_globaltype_t* wasm_global_type(const wasm_global_t* global) {
@@ -665,13 +665,13 @@ void wasm_global_set(wasm_global_t* global, wasm_val_t val) {
 
 // Table Instances
 
-WASM_DEFINE_REF(table)
+WASM_DEFINE_REF(table, Table)
 
 wasm_table_t* wasm_table_new(wasm_store_t* store, const wasm_tabletype_t* type, wasm_ref_t* ref) {
   auto store_ = borrow(store);
   auto type_ = borrow(type);
   auto ref_ = borrow(ref);
-  return release(table::make(store_.it, type_.it, ref_.it));
+  return release(Table::make(store_.it, type_.it, ref_.it));
 }
 
 wasm_tabletype_t* wasm_table_type(const wasm_table_t* table) {
@@ -698,15 +698,15 @@ wasm_table_size_t wasm_table_grow(wasm_table_t* table, wasm_table_size_t delta) 
 
 // Memory Instances
 
-WASM_DEFINE_REF(memory)
+WASM_DEFINE_REF(memory, Memory)
 
-wasm_memory_t* wasm_memory_new(wasm_store_t* store, const wasm_memtype_t* type) {
+wasm_memory_t* wasm_memory_new(wasm_store_t* store, const wasm_memorytype_t* type) {
   auto store_ = borrow(store);
   auto type_ = borrow(type);
-  return release(memory::make(store_.it, type_.it));
+  return release(Memory::make(store_.it, type_.it));
 }
 
-wasm_memtype_t* wasm_memory_type(const wasm_memory_t* memory) {
+wasm_memorytype_t* wasm_memory_type(const wasm_memory_t* memory) {
   return release(memory->type());
 }
 
@@ -729,52 +729,52 @@ wasm_memory_pages_t wasm_memory_grow(wasm_memory_t* memory, wasm_memory_pages_t 
 
 // Externals
 
-WASM_DEFINE_REF(external)
-WASM_DEFINE_VEC(external, *)
+WASM_DEFINE_REF(extern, Extern)
+WASM_DEFINE_VEC(extern, Extern, *)
 
-const wasm_external_t* wasm_func_as_external(const wasm_func_t* func) {
-  return hide(static_cast<const wasm::external*>(reveal(func)));
+const wasm_extern_t* wasm_func_as_extern(const wasm_func_t* func) {
+  return hide(static_cast<const Extern*>(reveal(func)));
 }
-const wasm_external_t* wasm_global_as_external(const wasm_global_t* global) {
-  return hide(static_cast<const wasm::external*>(reveal(global)));
+const wasm_extern_t* wasm_global_as_extern(const wasm_global_t* global) {
+  return hide(static_cast<const Extern*>(reveal(global)));
 }
-const wasm_external_t* wasm_table_as_external(const wasm_table_t* table) {
-  return hide(static_cast<const wasm::external*>(reveal(table)));
+const wasm_extern_t* wasm_table_as_extern(const wasm_table_t* table) {
+  return hide(static_cast<const Extern*>(reveal(table)));
 }
-const wasm_external_t* wasm_memory_as_external(const wasm_memory_t* memory) {
-  return hide(static_cast<const wasm::external*>(reveal(memory)));
+const wasm_extern_t* wasm_memory_as_extern(const wasm_memory_t* memory) {
+  return hide(static_cast<const Extern*>(reveal(memory)));
 }
 
-wasm_externkind_t wasm_external_kind(const wasm_external_t* external) {
+wasm_externkind_t wasm_extern_kind(const wasm_extern_t* external) {
   return hide(external->kind());
 }
 
-const wasm_func_t* wasm_external_as_func(const wasm_external_t* external) {
+const wasm_func_t* wasm_extern_as_func(const wasm_extern_t* external) {
   return hide(external->func());
 }
-const wasm_global_t* wasm_external_as_global(const wasm_external_t* external) {
+const wasm_global_t* wasm_extern_as_global(const wasm_extern_t* external) {
   return hide(external->global());
 }
-const wasm_table_t* wasm_external_as_table(const wasm_external_t* external) {
+const wasm_table_t* wasm_extern_as_table(const wasm_extern_t* external) {
   return hide(external->table());
 }
-const wasm_memory_t* wasm_external_as_memory(const wasm_external_t* external) {
+const wasm_memory_t* wasm_extern_as_memory(const wasm_extern_t* external) {
   return hide(external->memory());
 }
 
 
 // Module Instances
 
-WASM_DEFINE_REF(instance)
+WASM_DEFINE_REF(instance, Instance)
 
-wasm_instance_t* wasm_instance_new(wasm_store_t* store, const wasm_module_t* module, wasm_external_vec_t imports) {
+wasm_instance_t* wasm_instance_new(wasm_store_t* store, const wasm_module_t* module, wasm_extern_vec_t imports) {
   auto store_ = borrow(store);
   auto module_ = borrow(module);
   auto imports_ = borrow(imports);
-  return release(instance::make(store_.it, module_.it, imports_.it));
+  return release(Instance::make(store_.it, module_.it, imports_.it));
 }
 
-wasm_external_vec_t wasm_instance_exports(const wasm_instance_t* instance) {
+wasm_extern_vec_t wasm_instance_exports(const wasm_instance_t* instance) {
   return release(instance->exports());
 }
 

--- a/src/wasm-v8.cc
+++ b/src/wasm-v8.cc
@@ -293,7 +293,7 @@ auto valtype::make(valkind k) -> own<valtype*> {
   return own<valtype*>(seal<valtype>(valtypes[k]));
 }
 
-auto valtype::clone() const -> own<valtype*> {
+auto valtype::copy() const -> own<valtype*> {
   return make(kind());
 }
 
@@ -322,12 +322,12 @@ void externtype::operator delete(void *p) {
   ::operator delete(p);
 }
 
-auto externtype::clone() const -> own<externtype*> {
+auto externtype::copy() const -> own<externtype*> {
   switch (kind()) {
-    case EXTERN_FUNC: return func()->clone();
-    case EXTERN_GLOBAL: return global()->clone();
-    case EXTERN_TABLE: return table()->clone();
-    case EXTERN_MEMORY: return memory()->clone();
+    case EXTERN_FUNC: return func()->copy();
+    case EXTERN_GLOBAL: return global()->copy();
+    case EXTERN_TABLE: return table()->copy();
+    case EXTERN_MEMORY: return memory()->copy();
   }
 }
 
@@ -358,8 +358,8 @@ auto functype::make(vec<valtype*>&& params, vec<valtype*>&& results)
     : own<functype*>();
 }
 
-auto functype::clone() const -> own<functype*> {
-  return make(params().clone(), results().clone());
+auto functype::copy() const -> own<functype*> {
+  return make(params().copy(), results().copy());
 }
 
 auto functype::params() const -> const vec<valtype*>& {
@@ -401,8 +401,8 @@ auto globaltype::make(own<valtype*>&& content, wasm::mut mut) -> own<globaltype*
     : own<globaltype*>();
 }
 
-auto globaltype::clone() const -> own<globaltype*> {
-  return make(content()->clone(), mut());
+auto globaltype::copy() const -> own<globaltype*> {
+  return make(content()->copy(), mut());
 }
 
 auto globaltype::content() const -> const own<valtype*>& {
@@ -444,8 +444,8 @@ auto tabletype::make(own<valtype*>&& element, wasm::limits limits) -> own<tablet
     : own<tabletype*>();
 }
 
-auto tabletype::clone() const -> own<tabletype*> {
-  return make(element()->clone(), limits());
+auto tabletype::copy() const -> own<tabletype*> {
+  return make(element()->copy(), limits());
 }
 
 auto tabletype::element() const -> const own<valtype*>& {
@@ -484,7 +484,7 @@ auto memtype::make(wasm::limits limits) -> own<memtype*> {
   return own<memtype*>(seal<memtype>(new(std::nothrow) memtype_impl(limits)));
 }
 
-auto memtype::clone() const -> own<memtype*> {
+auto memtype::copy() const -> own<memtype*> {
   return memtype::make(limits());
 }
 
@@ -530,8 +530,8 @@ auto importtype::make(wasm::name&& module, wasm::name&& name, own<externtype*>&&
     : own<importtype*>();
 }
 
-auto importtype::clone() const -> own<importtype*> {
-  return make(module().clone(), name().clone(), type()->clone());
+auto importtype::copy() const -> own<importtype*> {
+  return make(module().copy(), name().copy(), type()->copy());
 }
 
 auto importtype::module() const -> const wasm::name& {
@@ -574,8 +574,8 @@ auto exporttype::make(own<wasm::name>&& name, own<externtype*>&& type) -> own<ex
     : own<exporttype*>();
 }
 
-auto exporttype::clone() const -> own<exporttype*> {
-  return make(name().clone(), type()->clone());
+auto exporttype::copy() const -> own<exporttype*> {
+  return make(name().copy(), type()->copy());
 }
 
 auto exporttype::name() const -> const wasm::name& {
@@ -805,7 +805,7 @@ struct ref_impl {
     if (data) data->drop();
   }
 
-  auto clone() const -> own<Ref*> {
+  auto copy() const -> own<Ref*> {
     if (data) data->take();
     return own<Ref*>(seal<Ref>(new(std::nothrow) ref_impl(data)));
   }
@@ -842,8 +842,8 @@ void ref::operator delete(void *p) {
   ::operator delete(p);
 }
 
-auto ref::clone() const -> own<ref*> {
-  return impl(this)->clone();
+auto ref::copy() const -> own<ref*> {
+  return impl(this)->copy();
 }
 
 auto ref::get_host_info() const -> void* {
@@ -875,8 +875,8 @@ template<> struct implement<module> { using type = module_impl; };
 
 module::~module() {}
 
-auto module::clone() const -> own<module*> {
-  return impl(this)->clone();
+auto module::copy() const -> own<module*> {
+  return impl(this)->copy();
 }
 
 auto module::validate(own<store*>& store_abs, const vec<byte_t>& binary) -> bool {
@@ -921,7 +921,7 @@ auto module::make(own<store*>& store_abs, const vec<byte_t>& binary) -> own<modu
 }
 
 auto module::imports() const -> vec<importtype*> {
-  return impl(this)->data->imports.clone();
+  return impl(this)->data->imports.copy();
 /* OBSOLETE?
   auto store = module->store();
   auto isolate = store->isolate();
@@ -956,7 +956,7 @@ auto module::imports() const -> vec<importtype*> {
 }
 
 auto module::exports() const -> vec<exporttype*> {
-  return impl(this)->data->exports.clone();
+  return impl(this)->data->exports.copy();
 /* OBSOLETE?
   auto store = module->store();
   auto isolate = store->isolate();
@@ -1005,8 +1005,8 @@ template<> struct implement<hostobj> { using type = hostobj_impl; };
 
 hostobj::~hostobj() {}
 
-auto hostobj::clone() const -> own<hostobj*> {
-  return impl(this)->clone();
+auto hostobj::copy() const -> own<hostobj*> {
+  return impl(this)->copy();
 }
 
 auto hostobj::make(own<store*>& store_abs) -> own<hostobj*> {
@@ -1035,8 +1035,8 @@ template<> struct implement<external> { using type = external_impl; };
 
 external::~external() {}
 
-auto external::clone() const -> own<external*> {
-  return impl(this)->clone();
+auto external::copy() const -> own<external*> {
+  return impl(this)->copy();
 }
 
 auto external::kind() const -> externkind {
@@ -1108,8 +1108,8 @@ template<> struct implement<func> { using type = func_impl; };
 
 func::~func() {}
 
-auto func::clone() const -> own<func*> {
-  return impl(this)->clone();
+auto func::copy() const -> own<func*> {
+  return impl(this)->copy();
 }
 
 namespace {
@@ -1130,9 +1130,9 @@ auto make_func(own<store*>& store_abs, const own<functype*>& type) -> own<func*>
   if (maybe_func_obj.IsEmpty()) return own<func*>();
   auto func_obj = maybe_func_obj.ToLocalChecked();
 
-  auto type_clone = type->clone();
-  if (!type_clone) return own<func*>();
-  auto data = make_own(new(std::nothrow) func_data(store, func_obj, type_clone));
+  auto type_copy = type->copy();
+  if (!type_copy) return own<func*>();
+  auto data = make_own(new(std::nothrow) func_data(store, func_obj, type_copy));
   if (data) v8_data->SetAlignedPointerInInternalField(0, data.get());
   return func_impl::make(data);
 }
@@ -1160,7 +1160,7 @@ auto func::make(
 }
 
 auto func::type() const -> own<functype*> {
-  return impl(this)->data->type->clone();
+  return impl(this)->data->type->copy();
 }
 
 auto func::call(const vec<val>& args) const -> vec<val> {
@@ -1255,8 +1255,8 @@ template<> struct implement<global> { using type = global_impl; };
 
 global::~global() {}
 
-auto global::clone() const -> own<global*> {
-  return impl(this)->clone();
+auto global::copy() const -> own<global*> {
+  return impl(this)->copy();
 }
 
 auto global::make(own<store*>& store_abs, const own<globaltype*>& type, const val& val) -> own<global*> {
@@ -1281,14 +1281,14 @@ auto global::make(own<store*>& store_abs, const own<globaltype*>& type, const va
   if (maybe_obj.IsEmpty()) return own<global*>();
   auto obj = maybe_obj.ToLocalChecked();
 
-  auto type_clone = type->clone();
-  if (!type_clone) return own<global*>();
-  auto data = make_own(new(std::nothrow) global_data(store, obj, type_clone));
+  auto type_copy = type->copy();
+  if (!type_copy) return own<global*>();
+  auto data = make_own(new(std::nothrow) global_data(store, obj, type_copy));
   return global_impl::make(data);
 }
 
 auto global::type() const -> own<globaltype*> {
-  return impl(this)->data->type->clone();
+  return impl(this)->data->type->copy();
 }
 
 auto global::get() const -> own<val> {
@@ -1346,8 +1346,8 @@ template<> struct implement<table> { using type = table_impl; };
 
 table::~table() {}
 
-auto table::clone() const -> own<table*> {
-  return impl(this)->clone();
+auto table::copy() const -> own<table*> {
+  return impl(this)->copy();
 }
 
 auto table::make(own<store*>& store_abs, const own<tabletype*>& type, const own<ref*>& ref) -> own<table*> {
@@ -1366,15 +1366,15 @@ auto table::make(own<store*>& store_abs, const own<tabletype*>& type, const own<
   if (maybe_obj.IsEmpty()) return own<table*>();
   auto obj = maybe_obj.ToLocalChecked();
 
-  auto type_clone = type->clone();
-  if (!type_clone) return own<table*>();
-  auto data = make_own(new(std::nothrow) table_data(store, obj, type_clone));
+  auto type_copy = type->copy();
+  if (!type_copy) return own<table*>();
+  auto data = make_own(new(std::nothrow) table_data(store, obj, type_copy));
   return table_impl::make(data);
 }
 
 auto table::type() const -> own<tabletype*> {
   // TODO: query and update min
-  return impl(this)->data->type->clone();
+  return impl(this)->data->type->copy();
 }
 
 auto table::get(size_t index) const -> own<ref*> {
@@ -1409,8 +1409,8 @@ template<> struct implement<memory> { using type = memory_impl; };
 
 memory::~memory() {}
 
-auto memory::clone() const -> own<memory*> {
-  return impl(this)->clone();
+auto memory::copy() const -> own<memory*> {
+  return impl(this)->copy();
 }
 
 auto memory::make(own<store*>& store_abs, const own<memtype*>& type) -> own<memory*> {
@@ -1425,15 +1425,15 @@ auto memory::make(own<store*>& store_abs, const own<memtype*>& type) -> own<memo
   if (maybe_obj.IsEmpty()) return own<memory*>();
   auto obj = maybe_obj.ToLocalChecked();
 
-  auto type_clone = type->clone();
-  if (!type_clone) return own<memory*>();
-  auto data = make_own(new(std::nothrow) memory_data(store, obj, type_clone));
+  auto type_copy = type->copy();
+  if (!type_copy) return own<memory*>();
+  auto data = make_own(new(std::nothrow) memory_data(store, obj, type_copy));
   return memory_impl::make(data);
 }
 
 auto memory::type() const -> own<memtype*> {
   // TODO: query and update min
-  return impl(this)->data->type->clone();
+  return impl(this)->data->type->copy();
 }
 
 auto memory::data() const -> byte_t* {
@@ -1468,8 +1468,8 @@ template<> struct implement<instance> { using type = instance_impl; };
 
 instance::~instance() {}
 
-auto instance::clone() const -> own<instance*> {
-  return impl(this)->clone();
+auto instance::copy() const -> own<instance*> {
+  return impl(this)->copy();
 }
 
 auto instance::make(own<store*>& store_abs, const own<module*>& module_abs, const vec<external*>& imports) -> own<instance*> {
@@ -1529,25 +1529,25 @@ auto instance::make(own<store*>& store_abs, const own<module*>& module_abs, cons
     switch (type->kind()) {
       case EXTERN_FUNC: {
         auto func_obj = v8::Local<v8::Function>::Cast(obj);
-        auto functype = type->func()->clone();
+        auto functype = type->func()->copy();
         if (!functype) return own<instance*>();
         auto data = make_own(new(std::nothrow) func_data(store, func_obj, functype));
         exports[i].reset(func_impl::make(data));
       } break;
       case EXTERN_GLOBAL: {
-        auto globaltype = type->global()->clone();
+        auto globaltype = type->global()->copy();
         if (!globaltype) return own<instance*>();
         auto data = make_own(new(std::nothrow) global_data(store, obj, globaltype));
         exports[i].reset(global_impl::make(data));
       } break;
       case EXTERN_TABLE: {
-        auto tabletype = type->table()->clone();
+        auto tabletype = type->table()->copy();
         if (!tabletype) return own<instance*>();
         auto data = make_own(new(std::nothrow) table_data(store, obj, tabletype));
         exports[i].reset(table_impl::make(data));
       } break;
       case EXTERN_MEMORY: {
-        auto memtype = type->memory()->clone();
+        auto memtype = type->memory()->copy();
         if (!memtype) return own<instance*>();
         auto data = make_own(new(std::nothrow) memory_data(store, obj, memtype));
         exports[i].reset(memory_impl::make(data));
@@ -1560,7 +1560,7 @@ auto instance::make(own<store*>& store_abs, const own<module*>& module_abs, cons
 }
 
 auto instance::exports() const -> vec<external*> {
-  return impl(this)->data->exports.clone();
+  return impl(this)->data->exports.copy();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/wasm-v8.cc
+++ b/src/wasm-v8.cc
@@ -44,44 +44,46 @@ auto seal(const typename implement <C>::type* x) -> const C* {
 ///////////////////////////////////////////////////////////////////////////////
 // Runtime Environment
 
-// Initialisation
+// Configuration
 
-struct config_impl {};
+struct ConfigImpl {};
 
-template<> struct implement<config> { using type = config_impl; };
+template<> struct implement<Config> { using type = ConfigImpl; };
 
-config::~config() {
-  impl(this)->~config_impl();
+Config::~Config() {
+  impl(this)->~ConfigImpl();
 }
 
-void config::operator delete(void *p) {
+void Config::operator delete(void *p) {
   ::operator delete(p);
 }
 
-auto config::make() -> own<config*> {
-  return own<config*>(seal<config>(new(std::nothrow) config_impl()));
+auto Config::make() -> own<Config*> {
+  return own<Config*>(seal<Config>(new(std::nothrow) ConfigImpl()));
 }
 
 
-struct engine_impl {
-  ~engine_impl() {
+// Engine
+
+struct EngineImpl {
+  ~EngineImpl() {
     v8::V8::Dispose();
     v8::V8::ShutdownPlatform();
   }
 };
 
-template<> struct implement<engine> { using type = engine_impl; };
+template<> struct implement<Engine> { using type = EngineImpl; };
 
-engine::~engine() {
-  impl(this)->~engine_impl();
+Engine::~Engine() {
+  impl(this)->~EngineImpl();
 }
 
-void engine::operator delete(void *p) {
+void Engine::operator delete(void *p) {
   ::operator delete(p);
 }
 
-auto engine::make(int argc, const char *const argv[], own<config*>&& config) -> own<engine*> {
-  auto engine = make_own(seal<wasm::engine>(new(std::nothrow) engine_impl));
+auto Engine::make(int argc, const char *const argv[], own<Config*>&& config) -> own<Engine*> {
+  auto engine = make_own(seal<Engine>(new(std::nothrow) EngineImpl));
   if (!engine) return engine;
   v8::V8::InitializeExternalStartupData(argv[0]);
   static std::unique_ptr<v8::Platform> platform =
@@ -113,80 +115,80 @@ enum v8_function_t {
   V8_F_COUNT,
 };
 
-class store_impl {
-  friend own<store*> store::make(own<engine*>&);
+class StoreImpl {
+  friend own<Store*> Store::make(own<Engine*>&);
 
   v8::Isolate::CreateParams create_params_;
   v8::Isolate *isolate_;
   v8::Eternal<v8::Context> context_;
-  v8::Eternal<v8::ObjectTemplate> callback_data_template_;
+  v8::Eternal<v8::ObjectTemplate> callbackData_template_;
   v8::Eternal<v8::String> strings_[V8_S_COUNT];
   v8::Eternal<v8::Function> functions_[V8_F_COUNT];
   v8::Eternal<v8::Object> cache_;
 
 public:
-  ~store_impl() {
+  ~StoreImpl() {
     context()->Exit();
     isolate_->Exit();
     isolate_->Dispose();
     delete create_params_.array_buffer_allocator;
   }
 
-  v8::Isolate* isolate() const {
+  auto isolate() const -> v8::Isolate* {
     return isolate_;
   }
 
-  v8::Local<v8::Context> context() const {
+  auto context() const -> v8::Local<v8::Context> {
     return context_.Get(isolate_);
   }
 
-  v8::Local<v8::ObjectTemplate> callback_data_template() const {
-    return callback_data_template_.Get(isolate_);
+  auto callbackData_template() const -> v8::Local<v8::ObjectTemplate> {
+    return callbackData_template_.Get(isolate_);
   }
 
-  v8::Local<v8::String> v8_string(v8_string_t i) const {
+  auto v8_string(v8_string_t i) const -> v8::Local<v8::String> {
     return strings_[i].Get(isolate_);
   }
 
-  v8::Local<v8::Function> v8_function(v8_function_t i) const {
+  auto v8_function(v8_function_t i) const -> v8::Local<v8::Function> {
     return functions_[i].Get(isolate_);
   }
 };
 
-template<> struct implement<store> { using type = store_impl; };
+template<> struct implement<Store> { using type = StoreImpl; };
 
-store::~store() {
-  impl(this)->~store_impl();
+Store::~Store() {
+  impl(this)->~StoreImpl();
 }
 
-void store::operator delete(void *p) {
+void Store::operator delete(void *p) {
   ::operator delete(p);
 }
 
-auto store::make(own<engine*>&) -> own<store*> {
-  auto store = make_own(new(std::nothrow) store_impl());
-  if (!store) return own<wasm::store*>();
+auto Store::make(own<Engine*>&) -> own<Store*> {
+  auto store = make_own(new(std::nothrow) StoreImpl());
+  if (!store) return own<Store*>();
   store->create_params_.array_buffer_allocator =
     v8::ArrayBuffer::Allocator::NewDefaultAllocator();
 
   auto isolate = v8::Isolate::New(store->create_params_);
-  if (!isolate) return own<wasm::store*>();
+  if (!isolate) return own<Store*>();
   {
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handle_scope(isolate);
 
     auto context = v8::Context::New(isolate);
-    if (context.IsEmpty()) return own<wasm::store*>();
+    if (context.IsEmpty()) return own<Store*>();
     v8::Context::Scope context_scope(context);
 
-    auto callback_data_template = v8::ObjectTemplate::New(isolate);
-    if (callback_data_template.IsEmpty()) return own<wasm::store*>();
-    callback_data_template->SetInternalFieldCount(1);
+    auto callbackData_template = v8::ObjectTemplate::New(isolate);
+    if (callbackData_template.IsEmpty()) return own<Store*>();
+    callbackData_template->SetInternalFieldCount(1);
 
     store->isolate_ = isolate;
     store->context_ = v8::Eternal<v8::Context>(isolate, context);
-    store->callback_data_template_ =
-      v8::Eternal<v8::ObjectTemplate>(isolate, callback_data_template);
+    store->callbackData_template_ =
+      v8::Eternal<v8::ObjectTemplate>(isolate, callbackData_template);
 
     static const char* const raw_strings[V8_S_COUNT] = {
       "function", "global", "table", "memory",
@@ -198,7 +200,7 @@ auto store::make(own<engine*>&) -> own<store*> {
     for (int i = 0; i < V8_S_COUNT; ++i) {
       auto maybe = v8::String::NewFromUtf8(isolate, raw_strings[i],
         v8::NewStringType::kNormal);
-      if (maybe.IsEmpty()) return own<wasm::store*>();
+      if (maybe.IsEmpty()) return own<Store*>();
       auto string = maybe.ToLocalChecked();
       store->strings_[i] = v8::Eternal<v8::String>(isolate, string);
     }
@@ -206,10 +208,10 @@ auto store::make(own<engine*>&) -> own<store*> {
     auto global = context->Global();
     auto maybe_wasm_name = v8::String::NewFromUtf8(isolate, "WebAssembly",
         v8::NewStringType::kNormal);
-    if (maybe_wasm_name.IsEmpty()) return own<wasm::store*>();
+    if (maybe_wasm_name.IsEmpty()) return own<Store*>();
     auto wasm_name = maybe_wasm_name.ToLocalChecked();
     auto maybe_wasm = global->Get(context, wasm_name);
-    if (maybe_wasm.IsEmpty()) return own<wasm::store*>();
+    if (maybe_wasm.IsEmpty()) return own<Store*>();
     auto wasm = v8::Local<v8::Object>::Cast(maybe_wasm.ToLocalChecked());
     v8::Local<v8::Object> wasm_module;
     v8::Local<v8::Object> wasm_global;
@@ -231,13 +233,13 @@ auto store::make(own<engine*>&) -> own<store*> {
     for (int i = 0; i < V8_F_COUNT; ++i) {
       auto maybe_name = v8::String::NewFromUtf8(isolate, raw_functions[i].name,
         v8::NewStringType::kNormal);
-      if (maybe_name.IsEmpty()) return own<wasm::store*>();
+      if (maybe_name.IsEmpty()) return own<Store*>();
       auto name = maybe_name.ToLocalChecked();
       assert(!raw_functions[i].carrier->IsEmpty());
       // TODO(wasm+): remove
       if ((*raw_functions[i].carrier)->IsUndefined()) continue;
       auto maybe_obj = (*raw_functions[i].carrier)->Get(context, name);
-      if (maybe_obj.IsEmpty()) return own<wasm::store*>();
+      if (maybe_obj.IsEmpty()) return own<Store*>();
       auto function = v8::Local<v8::Function>::Cast(maybe_obj.ToLocalChecked());
       store->functions_[i] = v8::Eternal<v8::Function>(isolate, function);
       if (i == V8_F_WEAKMAP) weakmap = function;
@@ -250,7 +252,7 @@ auto store::make(own<engine*>&) -> own<store*> {
     v8::Local<v8::Value> empty_args[] = {};
     auto maybe_cache =
       store->v8_function(V8_F_WEAKMAP)->NewInstance(context, 0, empty_args);
-    if (maybe_cache.IsEmpty()) return own<wasm::store*>();
+    if (maybe_cache.IsEmpty()) return own<Store*>();
     auto cache = v8::Local<v8::Object>::Cast(maybe_cache.ToLocalChecked());
     store->cache_ = v8::Eternal<v8::Object>(isolate, cache);
   }
@@ -258,7 +260,7 @@ auto store::make(own<engine*>&) -> own<store*> {
   store->isolate()->Enter();
   store->context()->Enter();
 
-  return make_own(seal<wasm::store>(store.release()));
+  return make_own(seal<Store>(store.release()));
 };
 
 
@@ -267,62 +269,62 @@ auto store::make(own<engine*>&) -> own<store*> {
 
 // Value Types
 
-struct valtype_impl {
-  valkind kind;
+struct ValTypeImpl {
+  ValKind kind;
 
-  valtype_impl(valkind kind) : kind(kind) {}
+  ValTypeImpl(ValKind kind) : kind(kind) {}
 };
 
-template<> struct implement<valtype> { using type = valtype_impl; };
+template<> struct implement<ValType> { using type = ValTypeImpl; };
 
-valtype_impl* valtypes[] = {
-  new valtype_impl(I32),
-  new valtype_impl(I64),
-  new valtype_impl(F32),
-  new valtype_impl(F64),
-  new valtype_impl(ANYREF),
-  new valtype_impl(FUNCREF),
+ValTypeImpl* valtypes[] = {
+  new ValTypeImpl(I32),
+  new ValTypeImpl(I64),
+  new ValTypeImpl(F32),
+  new ValTypeImpl(F64),
+  new ValTypeImpl(ANYREF),
+  new ValTypeImpl(FUNCREF),
 };
 
 
-valtype::~valtype() {}
+ValType::~ValType() {}
 
-void valtype::operator delete(void*) {}
+void ValType::operator delete(void*) {}
 
-auto valtype::make(valkind k) -> own<valtype*> {
-  return own<valtype*>(seal<valtype>(valtypes[k]));
+auto ValType::make(ValKind k) -> own<ValType*> {
+  return own<ValType*>(seal<ValType>(valtypes[k]));
 }
 
-auto valtype::copy() const -> own<valtype*> {
+auto ValType::copy() const -> own<ValType*> {
   return make(kind());
 }
 
-auto valtype::kind() const -> valkind {
+auto ValType::kind() const -> ValKind {
   return impl(this)->kind;
 }
 
 
 // Extern Types
 
-struct externtype_impl {
-  externkind kind;
+struct ExternTypeImpl {
+  ExternKind kind;
 
-  explicit externtype_impl(externkind kind) : kind(kind) {}
-  virtual ~externtype_impl() {}
+  explicit ExternTypeImpl(ExternKind kind) : kind(kind) {}
+  virtual ~ExternTypeImpl() {}
 };
 
-template<> struct implement<externtype> { using type = externtype_impl; };
+template<> struct implement<ExternType> { using type = ExternTypeImpl; };
 
 
-externtype::~externtype() {
-  impl(this)->~externtype_impl();
+ExternType::~ExternType() {
+  impl(this)->~ExternTypeImpl();
 }
 
-void externtype::operator delete(void *p) {
+void ExternType::operator delete(void *p) {
   ::operator delete(p);
 }
 
-auto externtype::copy() const -> own<externtype*> {
+auto ExternType::copy() const -> own<ExternType*> {
   switch (kind()) {
     case EXTERN_FUNC: return func()->copy();
     case EXTERN_GLOBAL: return global()->copy();
@@ -331,258 +333,258 @@ auto externtype::copy() const -> own<externtype*> {
   }
 }
 
-auto externtype::kind() const -> externkind {
+auto ExternType::kind() const -> ExternKind {
   return impl(this)->kind;
 }
 
 
 // Function Types
 
-struct functype_impl : externtype_impl {
-  vec<valtype*> params;
-  vec<valtype*> results;
+struct FuncTypeImpl : ExternTypeImpl {
+  vec<ValType*> params;
+  vec<ValType*> results;
 
-  functype_impl(vec<valtype*>& params, vec<valtype*>& results) :
-    externtype_impl(EXTERN_FUNC), params(std::move(params)), results(std::move(results)) {}
+  FuncTypeImpl(vec<ValType*>& params, vec<ValType*>& results) :
+    ExternTypeImpl(EXTERN_FUNC), params(std::move(params)), results(std::move(results)) {}
 };
 
-template<> struct implement<functype> { using type = functype_impl; };
+template<> struct implement<FuncType> { using type = FuncTypeImpl; };
 
 
-functype::~functype() {}
+FuncType::~FuncType() {}
 
-auto functype::make(vec<valtype*>&& params, vec<valtype*>&& results)
-  -> own<functype*> {
+auto FuncType::make(vec<ValType*>&& params, vec<ValType*>&& results)
+  -> own<FuncType*> {
   return params && results
-    ? own<functype*>(seal<functype>(new(std::nothrow) functype_impl(params, results)))
-    : own<functype*>();
+    ? own<FuncType*>(seal<FuncType>(new(std::nothrow) FuncTypeImpl(params, results)))
+    : own<FuncType*>();
 }
 
-auto functype::copy() const -> own<functype*> {
+auto FuncType::copy() const -> own<FuncType*> {
   return make(params().copy(), results().copy());
 }
 
-auto functype::params() const -> const vec<valtype*>& {
+auto FuncType::params() const -> const vec<ValType*>& {
   return impl(this)->params;
 }
 
-auto functype::results() const -> const vec<valtype*>& {
+auto FuncType::results() const -> const vec<ValType*>& {
   return impl(this)->results;
 }
 
 
-auto externtype::func() -> functype* {
-  return kind() == EXTERN_FUNC ? seal<functype>(static_cast<functype_impl*>(impl(this))) : nullptr;
+auto ExternType::func() -> FuncType* {
+  return kind() == EXTERN_FUNC ? seal<FuncType>(static_cast<FuncTypeImpl*>(impl(this))) : nullptr;
 }
 
-auto externtype::func() const -> const functype* {
-  return kind() == EXTERN_FUNC ? seal<functype>(static_cast<const functype_impl*>(impl(this))) : nullptr;
+auto ExternType::func() const -> const FuncType* {
+  return kind() == EXTERN_FUNC ? seal<FuncType>(static_cast<const FuncTypeImpl*>(impl(this))) : nullptr;
 }
 
 
 // Global Types
 
-struct globaltype_impl : externtype_impl {
-  own<valtype*> content;
-  wasm::mut mut;
+struct GlobalTypeImpl : ExternTypeImpl {
+  own<ValType*> content;
+  Mutability mutability;
 
-  globaltype_impl(own<valtype*>& content, wasm::mut mut) :
-    externtype_impl(EXTERN_GLOBAL), content(std::move(content)), mut(mut) {}
+  GlobalTypeImpl(own<ValType*>& content, Mutability mutability) :
+    ExternTypeImpl(EXTERN_GLOBAL), content(std::move(content)), mutability(mutability) {}
 };
 
-template<> struct implement<globaltype> { using type = globaltype_impl; };
+template<> struct implement<GlobalType> { using type = GlobalTypeImpl; };
 
 
-globaltype::~globaltype() {}
+GlobalType::~GlobalType() {}
 
-auto globaltype::make(own<valtype*>&& content, wasm::mut mut) -> own<globaltype*> {
+auto GlobalType::make(own<ValType*>&& content, Mutability mutability) -> own<GlobalType*> {
   return content
-    ? own<globaltype*>(seal<globaltype>(new(std::nothrow) globaltype_impl(content, mut)))
-    : own<globaltype*>();
+    ? own<GlobalType*>(seal<GlobalType>(new(std::nothrow) GlobalTypeImpl(content, mutability)))
+    : own<GlobalType*>();
 }
 
-auto globaltype::copy() const -> own<globaltype*> {
-  return make(content()->copy(), mut());
+auto GlobalType::copy() const -> own<GlobalType*> {
+  return make(content()->copy(), mutability());
 }
 
-auto globaltype::content() const -> const own<valtype*>& {
+auto GlobalType::content() const -> const own<ValType*>& {
   return impl(this)->content;
 }
 
-auto globaltype::mut() const -> wasm::mut {
-  return impl(this)->mut;
+auto GlobalType::mutability() const -> Mutability {
+  return impl(this)->mutability;
 }
 
 
-auto externtype::global() -> globaltype* {
-  return kind() == EXTERN_GLOBAL ? seal<globaltype>(static_cast<globaltype_impl*>(impl(this))) : nullptr;
+auto ExternType::global() -> GlobalType* {
+  return kind() == EXTERN_GLOBAL ? seal<GlobalType>(static_cast<GlobalTypeImpl*>(impl(this))) : nullptr;
 }
 
-auto externtype::global() const -> const globaltype* {
-  return kind() == EXTERN_GLOBAL ? seal<globaltype>(static_cast<const globaltype_impl*>(impl(this))) : nullptr;
+auto ExternType::global() const -> const GlobalType* {
+  return kind() == EXTERN_GLOBAL ? seal<GlobalType>(static_cast<const GlobalTypeImpl*>(impl(this))) : nullptr;
 }
 
 
 // Table Types
 
-struct tabletype_impl : externtype_impl {
-  own<valtype*> element;
-  wasm::limits limits;
+struct TableTypeImpl : ExternTypeImpl {
+  own<ValType*> element;
+  Limits limits;
 
-  tabletype_impl(own<valtype*>& element, wasm::limits limits) :
-    externtype_impl(EXTERN_TABLE), element(std::move(element)), limits(limits) {}
+  TableTypeImpl(own<ValType*>& element, Limits limits) :
+    ExternTypeImpl(EXTERN_TABLE), element(std::move(element)), limits(limits) {}
 };
 
-template<> struct implement<tabletype> { using type = tabletype_impl; };
+template<> struct implement<TableType> { using type = TableTypeImpl; };
 
 
-tabletype::~tabletype() {}
+TableType::~TableType() {}
 
-auto tabletype::make(own<valtype*>&& element, wasm::limits limits) -> own<tabletype*> {
+auto TableType::make(own<ValType*>&& element, Limits limits) -> own<TableType*> {
   return element
-    ? own<tabletype*>(seal<tabletype>(new(std::nothrow) tabletype_impl(element, limits)))
-    : own<tabletype*>();
+    ? own<TableType*>(seal<TableType>(new(std::nothrow) TableTypeImpl(element, limits)))
+    : own<TableType*>();
 }
 
-auto tabletype::copy() const -> own<tabletype*> {
+auto TableType::copy() const -> own<TableType*> {
   return make(element()->copy(), limits());
 }
 
-auto tabletype::element() const -> const own<valtype*>& {
+auto TableType::element() const -> const own<ValType*>& {
   return impl(this)->element;
 }
 
-auto tabletype::limits() const -> wasm::limits {
+auto TableType::limits() const -> Limits {
   return impl(this)->limits;
 }
 
 
-auto externtype::table() -> tabletype* {
-  return kind() == EXTERN_TABLE ? seal<tabletype>(static_cast<tabletype_impl*>(impl(this))) : nullptr;
+auto ExternType::table() -> TableType* {
+  return kind() == EXTERN_TABLE ? seal<TableType>(static_cast<TableTypeImpl*>(impl(this))) : nullptr;
 }
 
-auto externtype::table() const -> const tabletype* {
-  return kind() == EXTERN_TABLE ? seal<tabletype>(static_cast<const tabletype_impl*>(impl(this))) : nullptr;
+auto ExternType::table() const -> const TableType* {
+  return kind() == EXTERN_TABLE ? seal<TableType>(static_cast<const TableTypeImpl*>(impl(this))) : nullptr;
 }
 
 
 // Memory Types
 
-struct memtype_impl : externtype_impl {
-  wasm::limits limits;
+struct MemoryTypeImpl : ExternTypeImpl {
+  Limits limits;
 
-  memtype_impl(wasm::limits limits) :
-    externtype_impl(EXTERN_MEMORY), limits(limits) {}
+  MemoryTypeImpl(Limits limits) :
+    ExternTypeImpl(EXTERN_MEMORY), limits(limits) {}
 };
 
-template<> struct implement<memtype> { using type = memtype_impl; };
+template<> struct implement<MemoryType> { using type = MemoryTypeImpl; };
 
 
-memtype::~memtype() {}
+MemoryType::~MemoryType() {}
 
-auto memtype::make(wasm::limits limits) -> own<memtype*> {
-  return own<memtype*>(seal<memtype>(new(std::nothrow) memtype_impl(limits)));
+auto MemoryType::make(Limits limits) -> own<MemoryType*> {
+  return own<MemoryType*>(seal<MemoryType>(new(std::nothrow) MemoryTypeImpl(limits)));
 }
 
-auto memtype::copy() const -> own<memtype*> {
-  return memtype::make(limits());
+auto MemoryType::copy() const -> own<MemoryType*> {
+  return MemoryType::make(limits());
 }
 
-auto memtype::limits() const -> wasm::limits {
+auto MemoryType::limits() const -> Limits {
   return impl(this)->limits;
 }
 
 
-auto externtype::memory() -> memtype* {
-  return kind() == EXTERN_MEMORY ? seal<memtype>(static_cast<memtype_impl*>(impl(this))) : nullptr;
+auto ExternType::memory() -> MemoryType* {
+  return kind() == EXTERN_MEMORY ? seal<MemoryType>(static_cast<MemoryTypeImpl*>(impl(this))) : nullptr;
 }
 
-auto externtype::memory() const -> const memtype* {
-  return kind() == EXTERN_MEMORY ? seal<memtype>(static_cast<const memtype_impl*>(impl(this))) : nullptr;
+auto ExternType::memory() const -> const MemoryType* {
+  return kind() == EXTERN_MEMORY ? seal<MemoryType>(static_cast<const MemoryTypeImpl*>(impl(this))) : nullptr;
 }
 
 
 // Import Types
 
-struct importtype_impl {
-  wasm::name module;
-  wasm::name name;
-  own<externtype*> type;
+struct ImportTypeImpl {
+  Name module;
+  Name name;
+  own<ExternType*> type;
 
-  importtype_impl(wasm::name& module, wasm::name& name, own<externtype*>& type) :
+  ImportTypeImpl(Name& module, Name& name, own<ExternType*>& type) :
     module(std::move(module)), name(std::move(name)), type(std::move(type)) {}
 };
 
-template<> struct implement<importtype> { using type = importtype_impl; };
+template<> struct implement<ImportType> { using type = ImportTypeImpl; };
 
 
-importtype::~importtype() {
-  impl(this)->~importtype_impl();
+ImportType::~ImportType() {
+  impl(this)->~ImportTypeImpl();
 }
 
-void importtype::operator delete(void *p) {
+void ImportType::operator delete(void *p) {
   ::operator delete(p);
 }
 
-auto importtype::make(wasm::name&& module, wasm::name&& name, own<externtype*>&& type) -> own<importtype*> {
+auto ImportType::make(Name&& module, Name&& name, own<ExternType*>&& type) -> own<ImportType*> {
   return module && name && type
-    ? own<importtype*>(seal<importtype>(new(std::nothrow) importtype_impl(module, name, type)))
-    : own<importtype*>();
+    ? own<ImportType*>(seal<ImportType>(new(std::nothrow) ImportTypeImpl(module, name, type)))
+    : own<ImportType*>();
 }
 
-auto importtype::copy() const -> own<importtype*> {
+auto ImportType::copy() const -> own<ImportType*> {
   return make(module().copy(), name().copy(), type()->copy());
 }
 
-auto importtype::module() const -> const wasm::name& {
+auto ImportType::module() const -> const Name& {
   return impl(this)->module;
 }
 
-auto importtype::name() const -> const wasm::name& {
+auto ImportType::name() const -> const Name& {
   return impl(this)->name;
 }
 
-auto importtype::type() const -> const own<externtype*>& {
+auto ImportType::type() const -> const own<ExternType*>& {
   return impl(this)->type;
 }
 
 
 // Export Types
 
-struct exporttype_impl {
-  own<wasm::name> name;
-  own<externtype*> type;
+struct ExportTypeImpl {
+  Name name;
+  own<ExternType*> type;
 
-  exporttype_impl(own<wasm::name>& name, own<externtype*>& type) :
+  ExportTypeImpl(Name& name, own<ExternType*>& type) :
     name(std::move(name)), type(std::move(type)) {}
 };
 
-template<> struct implement<exporttype> { using type = exporttype_impl; };
+template<> struct implement<ExportType> { using type = ExportTypeImpl; };
 
 
-exporttype::~exporttype() {
-  impl(this)->~exporttype_impl();
+ExportType::~ExportType() {
+  impl(this)->~ExportTypeImpl();
 }
 
-void exporttype::operator delete(void *p) {
+void ExportType::operator delete(void *p) {
   ::operator delete(p);
 }
 
-auto exporttype::make(own<wasm::name>&& name, own<externtype*>&& type) -> own<exporttype*> {
+auto ExportType::make(Name&& name, own<ExternType*>&& type) -> own<ExportType*> {
   return name && type
-    ? own<exporttype*>(seal<exporttype>(new(std::nothrow) exporttype_impl(name, type)))
-    : own<exporttype*>();
+    ? own<ExportType*>(seal<ExportType>(new(std::nothrow) ExportTypeImpl(name, type)))
+    : own<ExportType*>();
 }
 
-auto exporttype::copy() const -> own<exporttype*> {
+auto ExportType::copy() const -> own<ExportType*> {
   return make(name().copy(), type()->copy());
 }
 
-auto exporttype::name() const -> const wasm::name& {
+auto ExportType::name() const -> const Name& {
   return impl(this)->name;
 }
 
-auto exporttype::type() const -> const own<externtype*>& {
+auto ExportType::type() const -> const own<ExternType*>& {
   return impl(this)->type;
 }
 
@@ -592,7 +594,7 @@ auto exporttype::type() const -> const own<externtype*>& {
 
 // Types
 
-v8::Local<v8::Value> valtype_to_v8(store_impl* store, const own<valtype*>& type) {
+v8::Local<v8::Value> valtype_to_v8(StoreImpl* store, const own<ValType*>& type) {
   v8_string_t string;
   switch (type->kind()) {
     case I32: string = V8_S_I32; break;
@@ -608,33 +610,33 @@ v8::Local<v8::Value> valtype_to_v8(store_impl* store, const own<valtype*>& type)
   return store->v8_string(string);
 }
 
-v8::Local<v8::Boolean> mut_to_v8(store_impl* store, mut mut) {
-  return v8::Boolean::New(store->isolate(), mut == VAR);
+v8::Local<v8::Boolean> mutability_to_v8(StoreImpl* store, Mutability mutability) {
+  return v8::Boolean::New(store->isolate(), mutability == VAR);
 }
 
-void limits_to_v8(store_impl* store, limits limits, v8::Local<v8::Object> desc) {
+void limits_to_v8(StoreImpl* store, Limits limits, v8::Local<v8::Object> desc) {
   auto isolate = store->isolate();
   auto context = store->context();
   void(desc->DefineOwnProperty(context, store->v8_string(V8_S_MINIMUM),
     v8::Integer::NewFromUnsigned(isolate, limits.min)));
-  if (limits.max != wasm::limits(0).max) {
+  if (limits.max != Limits(0).max) {
     void(desc->DefineOwnProperty(context, store->v8_string(V8_S_MAXIMUM),
       v8::Integer::NewFromUnsigned(isolate, limits.max)));
   }
 }
 
-v8::Local<v8::Object> globaltype_to_v8(store_impl* store, const own<globaltype*>& type) {
+v8::Local<v8::Object> globaltype_to_v8(StoreImpl* store, const own<GlobalType*>& type) {
   auto isolate = store->isolate();
   auto context = store->context();
   auto desc = v8::Object::New(isolate);
   void(desc->DefineOwnProperty(context, store->v8_string(V8_S_VALUE),
     valtype_to_v8(store, type->content())));
   void(desc->DefineOwnProperty(context, store->v8_string(V8_S_MUTABLE),
-    mut_to_v8(store, type->mut())));
+    mutability_to_v8(store, type->mutability())));
   return desc;
 }
 
-v8::Local<v8::Object> tabletype_to_v8(store_impl* store, const own<tabletype*>& type) {
+v8::Local<v8::Object> tabletype_to_v8(StoreImpl* store, const own<TableType*>& type) {
   auto isolate = store->isolate();
   auto context = store->context();
   auto desc = v8::Object::New(isolate);
@@ -644,7 +646,7 @@ v8::Local<v8::Object> tabletype_to_v8(store_impl* store, const own<tabletype*>& 
   return desc;
 }
 
-v8::Local<v8::Object> memtype_to_v8(store_impl* store, const own<memtype*>& type) {
+v8::Local<v8::Object> memorytype_to_v8(StoreImpl* store, const own<MemoryType*>& type) {
   auto isolate = store->isolate();
   auto context = store->context();
   auto desc = v8::Object::New(isolate);
@@ -667,7 +669,7 @@ wasm_externkind_t wasm_externkind_from_v8_kind(wasm_store_t* store, v8::Local<v8
   }
 }
 
-own wasm_externtype_t* wasm_externtype_new_from_v8_kind(wasm_store_t* store, v8::Local<v8::String> kind) {
+own wasm_ExternType_t* wasm_externtype_new_from_v8_kind(wasm_store_t* store, v8::Local<v8::String> kind) {
   // TODO: proper types
   switch (wasm_externkind_from_v8_kind(store, kind)) {
     case WASM_EXTERN_FUNC:
@@ -701,7 +703,7 @@ own wasm_byte_vec_t wasm_v8_to_byte_vec(v8::Local<v8::String> string) {
 
 // Values
 
-auto val_to_v8(store_impl* store, const val& v) -> v8::Local<v8::Value> {
+auto val_to_v8(StoreImpl* store, const Val& v) -> v8::Local<v8::Value> {
   auto isolate = store->isolate();
   switch (v.kind()) {
     case I32: return v8::Integer::NewFromUnsigned(isolate, v.i32());
@@ -720,19 +722,19 @@ auto val_to_v8(store_impl* store, const val& v) -> v8::Local<v8::Value> {
   }
 }
 
-auto v8_to_val(store_impl* store, v8::Local<v8::Value> value, const valtype* t) -> own<val> {
+auto v8_to_val(StoreImpl* store, v8::Local<v8::Value> value, const ValType* t) -> own<Val> {
   auto context = store->context();
   switch (t->kind()) {
-    case I32: return val(value->Int32Value(context).ToChecked());
+    case I32: return Val(value->Int32Value(context).ToChecked());
     case I64: UNIMPLEMENTED("i64 value");
     case F32: {
-      return val(static_cast<float32_t>(value->NumberValue(context).ToChecked()));
+      return Val(static_cast<float32_t>(value->NumberValue(context).ToChecked()));
     }
-    case F64: return val(value->NumberValue(context).ToChecked());
+    case F64: return Val(value->NumberValue(context).ToChecked());
     case ANYREF:
     case FUNCREF: {
       if (value->IsNull()) {
-        return val(nullptr);
+        return Val(nullptr);
       } else {
         UNIMPLEMENTED("ref value");
       }
@@ -754,11 +756,11 @@ auto v8_to_val(store_impl* store, v8::Local<v8::Value> value, const valtype* t) 
 // TODO: make refs casted persistent handles directly, 
 // and put extra info on object, with fallback to a weakmap when frozen
 
-class ref_data {
-  template<class, class> friend struct ref_impl;
+class RefData {
+  template<class, class> friend struct RefImpl;
 
   int count_ = 1;
-  store_impl* store_;
+  StoreImpl* store_;
   v8::Persistent<v8::Object> obj_;
   void* host_info_ = nullptr;
   void (*host_finalizer_)(void*) = nullptr;
@@ -770,12 +772,12 @@ class ref_data {
   }
   bool drop() {
     if (--count_ == 0) {
-      obj_.template SetWeak<ref_data>(this, &finalizer, v8::WeakCallbackType::kParameter);
+      obj_.template SetWeak<RefData>(this, &finalizer, v8::WeakCallbackType::kParameter);
     }
     return count_ == 0;
   }
 
-  static void finalizer(const v8::WeakCallbackInfo<ref_data>& info) {
+  static void finalizer(const v8::WeakCallbackInfo<RefData>& info) {
     auto data = info.GetParameter();
     assert(data->count_ == 0);
     if (data->host_finalizer_) (*data->host_finalizer_)(data->host_info_);
@@ -783,34 +785,34 @@ class ref_data {
   }
 
 public:
-  ref_data(store_impl* store, v8::Local<v8::Object> obj) :
+  RefData(StoreImpl* store, v8::Local<v8::Object> obj) :
     store_(store), obj_(store->isolate(), obj) {}
 
-  virtual ~ref_data() {}
+  virtual ~RefData() {}
 
-  auto store() const -> store_impl* {
+  auto store() const -> StoreImpl* {
     return store_;
   }
 };
 
 template<class Ref, class Data>
-struct ref_impl {
+struct RefImpl {
   Data* const data;
 
   static auto make(std::unique_ptr<Data>& data) -> own<Ref*> {
-    return own<Ref*>(data ? seal<Ref>(new(std::nothrow) ref_impl(data.release())) : nullptr);
+    return own<Ref*>(data ? seal<Ref>(new(std::nothrow) RefImpl(data.release())) : nullptr);
   }
   
-  ~ref_impl() {
+  ~RefImpl() {
     if (data) data->drop();
   }
 
   auto copy() const -> own<Ref*> {
     if (data) data->take();
-    return own<Ref*>(seal<Ref>(new(std::nothrow) ref_impl(data)));
+    return own<Ref*>(seal<Ref>(new(std::nothrow) RefImpl(data)));
   }
 
-  auto store() const -> store_impl* {
+  auto store() const -> StoreImpl* {
     return data->store_;
   }
 
@@ -828,29 +830,29 @@ struct ref_impl {
   }
 
 private:
-  explicit ref_impl(Data* data) : data(data) {}
+  explicit RefImpl(Data* data) : data(data) {}
 };
 
-template<> struct implement<ref> { using type = ref_impl<ref, ref_data>; };
+template<> struct implement<Ref> { using type = RefImpl<Ref, RefData>; };
 
 
-ref::~ref() {
-  impl(this)->~ref_impl();
+Ref::~Ref() {
+  impl(this)->~RefImpl();
 }
 
-void ref::operator delete(void *p) {
+void Ref::operator delete(void *p) {
   ::operator delete(p);
 }
 
-auto ref::copy() const -> own<ref*> {
+auto Ref::copy() const -> own<Ref*> {
   return impl(this)->copy();
 }
 
-auto ref::get_host_info() const -> void* {
+auto Ref::get_host_info() const -> void* {
   return impl(this)->get_host_info();
 }
 
-void ref::set_host_info(void* info, void (*finalizer)(void*)) {
+void Ref::set_host_info(void* info, void (*finalizer)(void*)) {
   impl(this)->set_host_info(info, finalizer);
 }
 
@@ -860,26 +862,26 @@ void ref::set_host_info(void* info, void (*finalizer)(void*)) {
 
 // Modules
 
-struct module_data : ref_data {
-  vec<importtype*> imports;
-  vec<exporttype*> exports;
+struct ModuleData : RefData {
+  vec<ImportType*> imports;
+  vec<ExportType*> exports;
 
-  module_data(store_impl* store, v8::Local<v8::Object> obj,
-    vec<importtype*>& imports, vec<exporttype*>& exports) :
-    ref_data(store, obj), imports(std::move(imports)), exports(std::move(exports)) {}
+  ModuleData(StoreImpl* store, v8::Local<v8::Object> obj,
+    vec<ImportType*>& imports, vec<ExportType*>& exports) :
+    RefData(store, obj), imports(std::move(imports)), exports(std::move(exports)) {}
 };
 
-using module_impl = ref_impl<module, module_data>;
-template<> struct implement<module> { using type = module_impl; };
+using ModuleImpl = RefImpl<Module, ModuleData>;
+template<> struct implement<Module> { using type = ModuleImpl; };
 
 
-module::~module() {}
+Module::~Module() {}
 
-auto module::copy() const -> own<module*> {
+auto Module::copy() const -> own<Module*> {
   return impl(this)->copy();
 }
 
-auto module::validate(own<store*>& store_abs, const vec<byte_t>& binary) -> bool {
+auto Module::validate(own<Store*>& store_abs, const vec<byte_t>& binary) -> bool {
   auto store = impl(store_abs.get());
   v8::Isolate* isolate = store->isolate();
   v8::HandleScope handle_scope(isolate);
@@ -895,7 +897,7 @@ auto module::validate(own<store*>& store_abs, const vec<byte_t>& binary) -> bool
   return result.ToLocalChecked()->IsTrue();
 }
 
-auto module::make(own<store*>& store_abs, const vec<byte_t>& binary) -> own<module*> {
+auto Module::make(own<Store*>& store_abs, const vec<byte_t>& binary) -> own<Module*> {
   auto store = impl(store_abs.get());
   auto isolate = store->isolate();
   auto context = store->context();
@@ -912,15 +914,15 @@ auto module::make(own<store*>& store_abs, const vec<byte_t>& binary) -> own<modu
 
   // TODO(wasm+): use JS API once available?
   auto imports_exports = wasm::bin::imports_exports(binary);
-  // TODO store->cache_set(module_obj, module);
+  // TODO store->cache_set(obj, module);
   auto& imports = std::get<0>(imports_exports);
   auto& exports = std::get<1>(imports_exports);
-  if (!imports || !exports) return own<module*>();
-  auto data = make_own(new(std::nothrow) module_data(store, obj, imports, exports));
-  return data ? module_impl::make(data) : own<module*>();
+  if (!imports || !exports) return own<Module*>();
+  auto data = make_own(new(std::nothrow) ModuleData(store, obj, imports, exports));
+  return data ? ModuleImpl::make(data) : own<Module*>();
 }
 
-auto module::imports() const -> vec<importtype*> {
+auto Module::imports() const -> vec<ImportType*> {
   return impl(this)->data->imports.copy();
 /* OBSOLETE?
   auto store = module->store();
@@ -955,7 +957,7 @@ auto module::imports() const -> vec<importtype*> {
 */
 }
 
-auto module::exports() const -> vec<exporttype*> {
+auto Module::exports() const -> vec<ExportType*> {
   return impl(this)->data->exports.copy();
 /* OBSOLETE?
   auto store = module->store();
@@ -987,183 +989,183 @@ auto module::exports() const -> vec<exporttype*> {
 */
 }
 
-auto module::serialize() const -> vec<byte_t> {
-  UNIMPLEMENTED("module::serialize");
+auto Module::serialize() const -> vec<byte_t> {
+  UNIMPLEMENTED("Module::serialize");
 }
 
-auto module::deserialize(vec<byte_t>& serialized) -> own<module*> {
-  UNIMPLEMENTED("module::deserialize");
+auto Module::deserialize(vec<byte_t>& serialized) -> own<Module*> {
+  UNIMPLEMENTED("Module::deserialize");
 }
 
 
-// Host Objects
+// Foreign Objects
 
-using hostobj_data = ref_data;
-using hostobj_impl = ref_impl<hostobj, hostobj_data>;
-template<> struct implement<hostobj> { using type = hostobj_impl; };
+using ForeignData = RefData;
+using ForeignImpl = RefImpl<Foreign, ForeignData>;
+template<> struct implement<Foreign> { using type = ForeignImpl; };
 
 
-hostobj::~hostobj() {}
+Foreign::~Foreign() {}
 
-auto hostobj::copy() const -> own<hostobj*> {
+auto Foreign::copy() const -> own<Foreign*> {
   return impl(this)->copy();
 }
 
-auto hostobj::make(own<store*>& store_abs) -> own<hostobj*> {
+auto Foreign::make(own<Store*>& store_abs) -> own<Foreign*> {
   auto store = impl(store_abs.get());
   auto isolate = store->isolate();
   v8::HandleScope handle_scope(isolate);
 
   auto obj = v8::Object::New(isolate);
-  auto data = make_own(new(std::nothrow) hostobj_data(store, obj));
-  return data ? hostobj_impl::make(data) : own<hostobj*>();
+  auto data = make_own(new(std::nothrow) ForeignData(store, obj));
+  return data ? ForeignImpl::make(data) : own<Foreign*>();
 }
 
 
 // Externals
 
-struct external_data : ref_data {
-  externkind kind;
+struct ExternData : RefData {
+  ExternKind kind;
 
-  external_data(store_impl* store, v8::Local<v8::Object> obj, externkind kind) :
-    ref_data(store, obj), kind(kind) {}
+  ExternData(StoreImpl* store, v8::Local<v8::Object> obj, ExternKind kind) :
+    RefData(store, obj), kind(kind) {}
 };
 
-using external_impl = ref_impl<external, external_data>;
-template<> struct implement<external> { using type = external_impl; };
+using ExternImpl = RefImpl<Extern, ExternData>;
+template<> struct implement<Extern> { using type = ExternImpl; };
 
 
-external::~external() {}
+Extern::~Extern() {}
 
-auto external::copy() const -> own<external*> {
+auto Extern::copy() const -> own<Extern*> {
   return impl(this)->copy();
 }
 
-auto external::kind() const -> externkind {
+auto Extern::kind() const -> ExternKind {
   return impl(this)->data->kind;
 }
 
-auto external::func() -> wasm::func* {
-  return kind() == EXTERN_FUNC ? static_cast<wasm::func*>(this) : nullptr;
+auto Extern::func() -> Func* {
+  return kind() == EXTERN_FUNC ? static_cast<Func*>(this) : nullptr;
 }
 
-auto external::global() -> wasm::global* {
-  return kind() == EXTERN_GLOBAL ? static_cast<wasm::global*>(this) : nullptr;
+auto Extern::global() -> Global* {
+  return kind() == EXTERN_GLOBAL ? static_cast<Global*>(this) : nullptr;
 }
 
-auto external::table() -> wasm::table* {
-  return kind() == EXTERN_TABLE ? static_cast<wasm::table*>(this) : nullptr;
+auto Extern::table() -> Table* {
+  return kind() == EXTERN_TABLE ? static_cast<Table*>(this) : nullptr;
 }
 
-auto external::memory() -> wasm::memory* {
-  return kind() == EXTERN_MEMORY ? static_cast<wasm::memory*>(this) : nullptr;
+auto Extern::memory() -> Memory* {
+  return kind() == EXTERN_MEMORY ? static_cast<Memory*>(this) : nullptr;
 }
 
-auto external::func() const -> const wasm::func* {
-  return kind() == EXTERN_FUNC ? static_cast<const wasm::func*>(this) : nullptr;
+auto Extern::func() const -> const Func* {
+  return kind() == EXTERN_FUNC ? static_cast<const Func*>(this) : nullptr;
 }
 
-auto external::global() const -> const wasm::global* {
-  return kind() == EXTERN_GLOBAL ? static_cast<const wasm::global*>(this) : nullptr;
+auto Extern::global() const -> const Global* {
+  return kind() == EXTERN_GLOBAL ? static_cast<const Global*>(this) : nullptr;
 }
 
-auto external::table() const -> const wasm::table* {
-  return kind() == EXTERN_TABLE ? static_cast<const wasm::table*>(this) : nullptr;
+auto Extern::table() const -> const Table* {
+  return kind() == EXTERN_TABLE ? static_cast<const Table*>(this) : nullptr;
 }
 
-auto external::memory() const -> const wasm::memory* {
-  return kind() == EXTERN_MEMORY ? static_cast<const wasm::memory*>(this) : nullptr;
+auto Extern::memory() const -> const Memory* {
+  return kind() == EXTERN_MEMORY ? static_cast<const Memory*>(this) : nullptr;
 }
 
-auto external_to_v8(const external* ex) -> v8::Local<v8::Object> {
+auto extern_to_v8(const Extern* ex) -> v8::Local<v8::Object> {
   return impl(ex)->v8_object();
 }
 
 
 // Function Instances
 
-struct func_data : external_data {
-  own<functype*> type;
+struct FuncData : ExternData {
+  own<FuncType*> type;
   enum { CALLBACK, CALLBACK_WITH_ENV } kind;
   union {
-    func::callback callback;
-    func::callback_with_env callback_with_env;
+    Func::callback callback;
+    Func::callback_with_env callback_with_env;
   };
   void* env;
   void (*finalizer)(void*);
 
-  func_data(store_impl* store, v8::Local<v8::Function> obj, own<functype*>& type) :
-    external_data(store, obj, EXTERN_FUNC), type(std::move(type)) {}
+  FuncData(StoreImpl* store, v8::Local<v8::Function> obj, own<FuncType*>& type) :
+    ExternData(store, obj, EXTERN_FUNC), type(std::move(type)) {}
 
-  ~func_data() {
+  ~FuncData() {
     if (kind == CALLBACK_WITH_ENV && finalizer) finalizer(env);
   }
 
   static void v8_callback(const v8::FunctionCallbackInfo<v8::Value>&);
 };
 
-using func_impl = ref_impl<func, func_data>;
-template<> struct implement<func> { using type = func_impl; };
+using FuncImpl = RefImpl<Func, FuncData>;
+template<> struct implement<Func> { using type = FuncImpl; };
 
 
-func::~func() {}
+Func::~Func() {}
 
-auto func::copy() const -> own<func*> {
+auto Func::copy() const -> own<Func*> {
   return impl(this)->copy();
 }
 
 namespace {
-auto make_func(own<store*>& store_abs, const own<functype*>& type) -> own<func*> {
+auto make_func(own<Store*>& store_abs, const own<FuncType*>& type) -> own<Func*> {
   auto store = impl(store_abs.get());
   auto isolate = store->isolate();
   v8::HandleScope handle_scope(isolate);
   auto context = store->context();
 
   // TODO(lowlevel): use V8 Foreign value
-  auto data_template = store->callback_data_template();
-  auto maybe_data = data_template->NewInstance(context);
-  if (maybe_data.IsEmpty()) return own<func*>();
-  auto v8_data = maybe_data.ToLocalChecked();
+  auto data_template = store->callbackData_template();
+  auto maybeData = data_template->NewInstance(context);
+  if (maybeData.IsEmpty()) return own<Func*>();
+  auto v8Data = maybeData.ToLocalChecked();
 
-  auto function_template = v8::FunctionTemplate::New(isolate, &func_data::v8_callback, v8_data);
+  auto function_template = v8::FunctionTemplate::New(isolate, &FuncData::v8_callback, v8Data);
   auto maybe_func_obj = function_template->GetFunction(context);
-  if (maybe_func_obj.IsEmpty()) return own<func*>();
+  if (maybe_func_obj.IsEmpty()) return own<Func*>();
   auto func_obj = maybe_func_obj.ToLocalChecked();
 
   auto type_copy = type->copy();
-  if (!type_copy) return own<func*>();
-  auto data = make_own(new(std::nothrow) func_data(store, func_obj, type_copy));
-  if (data) v8_data->SetAlignedPointerInInternalField(0, data.get());
-  return func_impl::make(data);
+  if (!type_copy) return own<Func*>();
+  auto data = make_own(new(std::nothrow) FuncData(store, func_obj, type_copy));
+  if (data) v8Data->SetAlignedPointerInInternalField(0, data.get());
+  return FuncImpl::make(data);
 }
 }
 
-auto func::make(own<store*>& store_abs, const own<functype*>& type, func::callback callback) -> own<func*> {
+auto Func::make(own<Store*>& store_abs, const own<FuncType*>& type, Func::callback callback) -> own<Func*> {
   auto func = make_func(store_abs, type);
   auto data = impl(func.get())->data;
-  data->kind = func_data::CALLBACK;
+  data->kind = FuncData::CALLBACK;
   data->callback = callback;
   return func;
 }
 
-auto func::make(
-  own<store*>& store_abs, const own<functype*>& type,
+auto Func::make(
+  own<Store*>& store_abs, const own<FuncType*>& type,
   callback_with_env callback, void* env, void (*finalizer)(void*)
-) -> own<func*> {
+) -> own<Func*> {
   auto func = make_func(store_abs, type);
   auto data = impl(func.get())->data;
-  data->kind = func_data::CALLBACK_WITH_ENV;
+  data->kind = FuncData::CALLBACK_WITH_ENV;
   data->callback_with_env = callback;
   data->env = env;
   data->finalizer = finalizer;
   return func;
 }
 
-auto func::type() const -> own<functype*> {
+auto Func::type() const -> own<FuncType*> {
   return impl(this)->data->type->copy();
 }
 
-auto func::call(const vec<val>& args) const -> vec<val> {
+auto Func::call(const vec<Val>& args) const -> vec<Val> {
   auto func = impl(this);
   auto store = func->store();
   auto isolate = store->isolate();
@@ -1185,24 +1187,24 @@ auto func::call(const vec<val>& args) const -> vec<val> {
   auto v8_function = v8::Local<v8::Function>::Cast(func->v8_object());
   auto maybe_result =
     v8_function->Call(context, v8::Undefined(isolate), args.size(), v8_args.get());
-  if (maybe_result.IsEmpty()) return vec<val>::invalid();
+  if (maybe_result.IsEmpty()) return vec<Val>::invalid();
   auto result = maybe_result.ToLocalChecked();
 
   if (type_results.size() == 0) {
     assert(result->IsUndefined());
-    return vec<val>::make();
+    return vec<Val>::make();
   } else if (type_results.size() == 1) {
     assert(!result->IsUndefined());
-    return vec<val>::make(v8_to_val(store, result, type_results[0]));
+    return vec<Val>::make(v8_to_val(store, result, type_results[0]));
   } else {
     UNIMPLEMENTED("multiple results");
   }
 }
 
-void func_data::v8_callback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-  auto v8_data = v8::Local<v8::Object>::Cast(info.Data());
-  auto self = reinterpret_cast<func_data*>(
-    v8_data->GetAlignedPointerFromInternalField(0));
+void FuncData::v8_callback(const v8::FunctionCallbackInfo<v8::Value>& info) {
+  auto v8Data = v8::Local<v8::Object>::Cast(info.Data());
+  auto self = reinterpret_cast<FuncData*>(
+    v8Data->GetAlignedPointerFromInternalField(0));
   auto store = self->store();
   auto isolate = store->isolate();
   v8::HandleScope handle_scope(isolate);
@@ -1214,12 +1216,12 @@ void func_data::v8_callback(const v8::FunctionCallbackInfo<v8::Value>& info) {
 
   assert(type_params.size() == info.Length());
 
-  auto args = vec<val>::make_uninitialized(type_params.size());
+  auto args = vec<Val>::make_uninitialized(type_params.size());
   for (size_t i = 0; i < type_params.size(); ++i) {
     args[i] = v8_to_val(store, info[i], type_params[i]);
   }
 
-  auto results = vec<val>::invalid();
+  auto results = vec<Val>::invalid();
   if (self->kind == CALLBACK_WITH_ENV) {
     results = self->callback_with_env(self->env, args);
   } else {
@@ -1242,24 +1244,24 @@ void func_data::v8_callback(const v8::FunctionCallbackInfo<v8::Value>& info) {
 
 // Global Instances
 
-struct global_data : external_data {
-  own<globaltype*> type;
+struct GlobalData : ExternData {
+  own<GlobalType*> type;
 
-  global_data(store_impl* store, v8::Local<v8::Object> obj, own<globaltype*>& type) :
-    external_data(store, obj, EXTERN_GLOBAL), type(std::move(type)) {}
+  GlobalData(StoreImpl* store, v8::Local<v8::Object> obj, own<GlobalType*>& type) :
+    ExternData(store, obj, EXTERN_GLOBAL), type(std::move(type)) {}
 };
 
-using global_impl = ref_impl<global, global_data>;
-template<> struct implement<global> { using type = global_impl; };
+using GlobalImpl = RefImpl<Global, GlobalData>;
+template<> struct implement<Global> { using type = GlobalImpl; };
 
 
-global::~global() {}
+Global::~Global() {}
 
-auto global::copy() const -> own<global*> {
+auto Global::copy() const -> own<Global*> {
   return impl(this)->copy();
 }
 
-auto global::make(own<store*>& store_abs, const own<globaltype*>& type, const val& val) -> own<global*> {
+auto Global::make(own<Store*>& store_abs, const own<GlobalType*>& type, const Val& val) -> own<Global*> {
   auto store = impl(store_abs.get());
   auto isolate = store->isolate();
   v8::HandleScope handle_scope(isolate);
@@ -1269,7 +1271,7 @@ auto global::make(own<store*>& store_abs, const own<globaltype*>& type, const va
 
   // TODO(wasm+): remove
   if (store->v8_function(V8_F_GLOBAL).IsEmpty()) {
-    UNIMPLEMENTED("global::make");
+    UNIMPLEMENTED("Global::make");
   }
 
   v8::Local<v8::Value> args[] = {
@@ -1278,20 +1280,20 @@ auto global::make(own<store*>& store_abs, const own<globaltype*>& type, const va
   };
   auto maybe_obj =
     store->v8_function(V8_F_GLOBAL)->NewInstance(context, 2, args);
-  if (maybe_obj.IsEmpty()) return own<global*>();
+  if (maybe_obj.IsEmpty()) return own<Global*>();
   auto obj = maybe_obj.ToLocalChecked();
 
   auto type_copy = type->copy();
-  if (!type_copy) return own<global*>();
-  auto data = make_own(new(std::nothrow) global_data(store, obj, type_copy));
-  return global_impl::make(data);
+  if (!type_copy) return own<Global*>();
+  auto data = make_own(new(std::nothrow) GlobalData(store, obj, type_copy));
+  return GlobalImpl::make(data);
 }
 
-auto global::type() const -> own<globaltype*> {
+auto Global::type() const -> own<GlobalType*> {
   return impl(this)->data->type->copy();
 }
 
-auto global::get() const -> own<val> {
+auto Global::get() const -> own<Val> {
   auto global = impl(this);
   auto store = global->store();
   auto isolate = store->isolate();
@@ -1300,18 +1302,18 @@ auto global::get() const -> own<val> {
 
   // TODO(wasm+): remove
   if (store->v8_function(V8_F_GLOBAL_GET).IsEmpty()) {
-    UNIMPLEMENTED("global::get");
+    UNIMPLEMENTED("Global::get");
   }
 
-  auto maybe_val =
+  auto maybe_value =
     store->v8_function(V8_F_GLOBAL_GET)->Call(context, global->v8_object(), 0, nullptr);
-  if (maybe_val.IsEmpty()) return val();
-  auto val = maybe_val.ToLocalChecked();
+  if (maybe_value.IsEmpty()) return Val();
+  auto value = maybe_value.ToLocalChecked();
 
-  return v8_to_val(store, val, this->type()->content().get());
+  return v8_to_val(store, value, this->type()->content().get());
 }
 
-void global::set(const val& val) {
+void Global::set(const Val& val) {
   auto global = impl(this);
   auto store = global->store();
   auto isolate = store->isolate();
@@ -1322,7 +1324,7 @@ void global::set(const val& val) {
 
   // TODO(wasm+): remove
   if (store->v8_function(V8_F_GLOBAL_SET).IsEmpty()) {
-    UNIMPLEMENTED("global::set");
+    UNIMPLEMENTED("Global::set");
   }
 
   v8::Local<v8::Value> args[] = { val_to_v8(store, val) };
@@ -1333,24 +1335,24 @@ void global::set(const val& val) {
 
 // Table Instances
 
-struct table_data : external_data {
-  own<tabletype*> type;
+struct TableData : ExternData {
+  own<TableType*> type;
 
-  table_data(store_impl* store, v8::Local<v8::Object> obj, own<tabletype*>& type) :
-    external_data(store, obj, EXTERN_TABLE), type(std::move(type)) {}
+  TableData(StoreImpl* store, v8::Local<v8::Object> obj, own<TableType*>& type) :
+    ExternData(store, obj, EXTERN_TABLE), type(std::move(type)) {}
 };
 
-using table_impl = ref_impl<table, table_data>;
-template<> struct implement<table> { using type = table_impl; };
+using TableImpl = RefImpl<Table, TableData>;
+template<> struct implement<Table> { using type = TableImpl; };
 
 
-table::~table() {}
+Table::~Table() {}
 
-auto table::copy() const -> own<table*> {
+auto Table::copy() const -> own<Table*> {
   return impl(this)->copy();
 }
 
-auto table::make(own<store*>& store_abs, const own<tabletype*>& type, const own<ref*>& ref) -> own<table*> {
+auto Table::make(own<Store*>& store_abs, const own<TableType*>& type, const own<Ref*>& ref) -> own<Table*> {
   auto store = impl(store_abs.get());
   auto isolate = store->isolate();
   v8::HandleScope handle_scope(isolate);
@@ -1363,116 +1365,116 @@ auto table::make(own<store*>& store_abs, const own<tabletype*>& type, const own<
   };
   auto maybe_obj =
     store->v8_function(V8_F_TABLE)->NewInstance(context, 2, args);
-  if (maybe_obj.IsEmpty()) return own<table*>();
+  if (maybe_obj.IsEmpty()) return own<Table*>();
   auto obj = maybe_obj.ToLocalChecked();
 
   auto type_copy = type->copy();
-  if (!type_copy) return own<table*>();
-  auto data = make_own(new(std::nothrow) table_data(store, obj, type_copy));
-  return table_impl::make(data);
+  if (!type_copy) return own<Table*>();
+  auto data = make_own(new(std::nothrow) TableData(store, obj, type_copy));
+  return TableImpl::make(data);
 }
 
-auto table::type() const -> own<tabletype*> {
+auto Table::type() const -> own<TableType*> {
   // TODO: query and update min
   return impl(this)->data->type->copy();
 }
 
-auto table::get(size_t index) const -> own<ref*> {
-  UNIMPLEMENTED("table::get");
+auto Table::get(size_t index) const -> own<Ref*> {
+  UNIMPLEMENTED("Table::get");
 }
 
-void table::set(size_t index, const own<ref*>& r) {
-  UNIMPLEMENTED("table::set");
+void Table::set(size_t index, const own<Ref*>& r) {
+  UNIMPLEMENTED("Table::set");
 }
 
-auto table::size() const -> size_t {
-  UNIMPLEMENTED("table::size");
+auto Table::size() const -> size_t {
+  UNIMPLEMENTED("Table::size");
 }
 
-auto table::grow(size_t delta) -> size_t {
-  UNIMPLEMENTED("table::grow");
+auto Table::grow(size_t delta) -> size_t {
+  UNIMPLEMENTED("Table::grow");
 }
 
 
 // Memory Instances
 
-struct memory_data : external_data {
-  own<memtype*> type;
+struct MemoryData : ExternData {
+  own<MemoryType*> type;
 
-  memory_data(store_impl* store, v8::Local<v8::Object> obj, own<memtype*>& type) :
-    external_data(store, obj, EXTERN_MEMORY), type(std::move(type)) {}
+  MemoryData(StoreImpl* store, v8::Local<v8::Object> obj, own<MemoryType*>& type) :
+    ExternData(store, obj, EXTERN_MEMORY), type(std::move(type)) {}
 };
 
-using memory_impl = ref_impl<memory, memory_data>;
-template<> struct implement<memory> { using type = memory_impl; };
+using MemoryImpl = RefImpl<Memory, MemoryData>;
+template<> struct implement<Memory> { using type = MemoryImpl; };
 
 
-memory::~memory() {}
+Memory::~Memory() {}
 
-auto memory::copy() const -> own<memory*> {
+auto Memory::copy() const -> own<Memory*> {
   return impl(this)->copy();
 }
 
-auto memory::make(own<store*>& store_abs, const own<memtype*>& type) -> own<memory*> {
+auto Memory::make(own<Store*>& store_abs, const own<MemoryType*>& type) -> own<Memory*> {
   auto store = impl(store_abs.get());
   auto isolate = store->isolate();
   v8::HandleScope handle_scope(isolate);
   auto context = store->context();
 
-  v8::Local<v8::Value> args[] = { memtype_to_v8(store, type) };
+  v8::Local<v8::Value> args[] = { memorytype_to_v8(store, type) };
   auto maybe_obj =
     store->v8_function(V8_F_MEMORY)->NewInstance(context, 1, args);
-  if (maybe_obj.IsEmpty()) return own<memory*>();
+  if (maybe_obj.IsEmpty()) return own<Memory*>();
   auto obj = maybe_obj.ToLocalChecked();
 
   auto type_copy = type->copy();
-  if (!type_copy) return own<memory*>();
-  auto data = make_own(new(std::nothrow) memory_data(store, obj, type_copy));
-  return memory_impl::make(data);
+  if (!type_copy) return own<Memory*>();
+  auto data = make_own(new(std::nothrow) MemoryData(store, obj, type_copy));
+  return MemoryImpl::make(data);
 }
 
-auto memory::type() const -> own<memtype*> {
+auto Memory::type() const -> own<MemoryType*> {
   // TODO: query and update min
   return impl(this)->data->type->copy();
 }
 
-auto memory::data() const -> byte_t* {
-  UNIMPLEMENTED("memory::data");
+auto Memory::data() const -> byte_t* {
+  UNIMPLEMENTED("Memory::data");
 }
 
-auto memory::data_size() const -> size_t {
-  UNIMPLEMENTED("memory::data_size");
+auto Memory::data_size() const -> size_t {
+  UNIMPLEMENTED("Memory::data_size");
 }
 
-auto memory::size() const -> pages_t {
-  UNIMPLEMENTED("memory::size");
+auto Memory::size() const -> pages_t {
+  UNIMPLEMENTED("Memory::size");
 }
 
-auto memory::grow(pages_t delta) -> pages_t {
-  UNIMPLEMENTED("memory::grow");
+auto Memory::grow(pages_t delta) -> pages_t {
+  UNIMPLEMENTED("Memory::grow");
 }
 
 
 // Module Instances
 
-struct instance_data : ref_data {
-  vec<external*> exports;
+struct InstanceData : RefData {
+  vec<Extern*> exports;
 
-  instance_data(store_impl* store, v8::Local<v8::Object> obj, vec<external*>& exports) :
-    ref_data(store, obj), exports(std::move(exports)) {}
+  InstanceData(StoreImpl* store, v8::Local<v8::Object> obj, vec<Extern*>& exports) :
+    RefData(store, obj), exports(std::move(exports)) {}
 };
 
-using instance_impl = ref_impl<instance, instance_data>;
-template<> struct implement<instance> { using type = instance_impl; };
+using InstanceImpl = RefImpl<Instance, InstanceData>;
+template<> struct implement<Instance> { using type = InstanceImpl; };
 
 
-instance::~instance() {}
+Instance::~Instance() {}
 
-auto instance::copy() const -> own<instance*> {
+auto Instance::copy() const -> own<Instance*> {
   return impl(this)->copy();
 }
 
-auto instance::make(own<store*>& store_abs, const own<module*>& module_abs, const vec<external*>& imports) -> own<instance*> {
+auto Instance::make(own<Store*>& store_abs, const own<Module*>& module_abs, const vec<Extern*>& imports) -> own<Instance*> {
   auto store = impl(store_abs.get());
   auto module = impl(module_abs.get());
   auto isolate = store->isolate();
@@ -1482,7 +1484,7 @@ auto instance::make(own<store*>& store_abs, const own<module*>& module_abs, cons
   v8::Local<v8::Value> imports_args[] = { module->v8_object() };
   auto imports_result = store->v8_function(V8_F_IMPORTS)->Call(
     context, v8::Undefined(isolate), 1, imports_args);
-  if (imports_result.IsEmpty()) return own<instance*>();
+  if (imports_result.IsEmpty()) return own<Instance*>();
   auto imports_array = v8::Local<v8::Array>::Cast(imports_result.ToLocalChecked());
   size_t imports_size = imports_array->Length();
 
@@ -1503,7 +1505,7 @@ auto instance::make(own<store*>& store_abs, const own<module*>& module_abs, cons
       void(imports_obj->DefineOwnProperty(context, module_str, module_obj));
     }
 
-    void(module_obj->DefineOwnProperty(context, name_str, external_to_v8(imports[i])));
+    void(module_obj->DefineOwnProperty(context, name_str, extern_to_v8(imports[i])));
   }
 
   v8::Local<v8::Value> instantiate_args[] = {module->v8_object(), imports_obj};
@@ -1514,13 +1516,13 @@ auto instance::make(own<store*>& store_abs, const own<module*>& module_abs, cons
   assert(!exports_obj.IsEmpty() && exports_obj->IsObject());
 
   auto export_types = module_abs->exports();
-  auto exports = vec<external*>::make_uninitialized(export_types.size());
-  if (!exports) return own<instance*>();
+  auto exports = vec<Extern*>::make_uninitialized(export_types.size());
+  if (!exports) return own<Instance*>();
   for (size_t i = 0; i < export_types.size(); ++i) {
     auto& name = export_types[i]->name();
     auto maybe_name_obj = v8::String::NewFromUtf8(isolate, name.get(),
       v8::NewStringType::kNormal, name.size());
-    if (maybe_name_obj.IsEmpty()) return own<instance*>();
+    if (maybe_name_obj.IsEmpty()) return own<Instance*>();
     auto name_obj = maybe_name_obj.ToLocalChecked();
     auto obj = v8::Local<v8::Function>::Cast(
       exports_obj->Get(context, name_obj).ToLocalChecked());
@@ -1528,38 +1530,37 @@ auto instance::make(own<store*>& store_abs, const own<module*>& module_abs, cons
     auto& type = export_types[i]->type();
     switch (type->kind()) {
       case EXTERN_FUNC: {
-        auto func_obj = v8::Local<v8::Function>::Cast(obj);
         auto functype = type->func()->copy();
-        if (!functype) return own<instance*>();
-        auto data = make_own(new(std::nothrow) func_data(store, func_obj, functype));
-        exports[i].reset(func_impl::make(data));
+        if (!functype) return own<Instance*>();
+        auto data = make_own(new(std::nothrow) FuncData(store, obj, functype));
+        exports[i].reset(FuncImpl::make(data));
       } break;
       case EXTERN_GLOBAL: {
         auto globaltype = type->global()->copy();
-        if (!globaltype) return own<instance*>();
-        auto data = make_own(new(std::nothrow) global_data(store, obj, globaltype));
-        exports[i].reset(global_impl::make(data));
+        if (!globaltype) return own<Instance*>();
+        auto data = make_own(new(std::nothrow) GlobalData(store, obj, globaltype));
+        exports[i].reset(GlobalImpl::make(data));
       } break;
       case EXTERN_TABLE: {
         auto tabletype = type->table()->copy();
-        if (!tabletype) return own<instance*>();
-        auto data = make_own(new(std::nothrow) table_data(store, obj, tabletype));
-        exports[i].reset(table_impl::make(data));
+        if (!tabletype) return own<Instance*>();
+        auto data = make_own(new(std::nothrow) TableData(store, obj, tabletype));
+        exports[i].reset(TableImpl::make(data));
       } break;
       case EXTERN_MEMORY: {
-        auto memtype = type->memory()->copy();
-        if (!memtype) return own<instance*>();
-        auto data = make_own(new(std::nothrow) memory_data(store, obj, memtype));
-        exports[i].reset(memory_impl::make(data));
+        auto memorytype = type->memory()->copy();
+        if (!memorytype) return own<Instance*>();
+        auto data = make_own(new(std::nothrow) MemoryData(store, obj, memorytype));
+        exports[i].reset(MemoryImpl::make(data));
       } break;
     }
   }
 
-  auto data = make_own(new(std::nothrow) instance_data(store, instance_obj, exports));
-  return instance_impl::make(data);
+  auto data = make_own(new(std::nothrow) InstanceData(store, instance_obj, exports));
+  return InstanceImpl::make(data);
 }
 
-auto instance::exports() const -> vec<external*> {
+auto Instance::exports() const -> vec<Extern*> {
   return impl(this)->data->exports.copy();
 }
 


### PR DESCRIPTION
* Rename `clone` to `copy`.
* Rename `mut` to `mutability`.
* Rename `memtype` to `memorytype`.
* Rename `external` (back) to `extern`.
* Rename `hostobj` to `foreign`.
* In C++ API, CamelCase all type names.
* In C API, add missing functions `wasm_ref_{get,set}_host_info*`.
