### PR TITLE
Update CMake files

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -13,5 +13,10 @@ function(example name source)
   target_link_libraries (${name} ${V8_LIBS} wasm_v8 pthread)
 endfunction(example)
 
+example(callback callback.c)
 example(hello hello.c)
+example(trap trap.c)
+
+example(callback_cpp callback.cc)
 example(hello_cpp hello.cc)
+example(trap_cpp trap.cc)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,11 +1,17 @@
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 
-add_executable (hello hello.c)
-target_include_directories(hello PRIVATE ${V8_INCLUDE})
-target_link_libraries (hello ${V8_LIBS} wasm_v8 pthread)
 configure_file(${V8V8}/out.gn/x64.release/natives_blob.bin
                ${CMAKE_CURRENT_BINARY_DIR}/natives_blob.bin
 	       COPYONLY)
 configure_file(${V8V8}/out.gn/x64.release/snapshot_blob.bin
                ${CMAKE_CURRENT_BINARY_DIR}/snapshot_blob.bin
 	       COPYONLY)
+
+function(example name source)
+  add_executable (${name} ${source})
+  target_include_directories(${name} PRIVATE ${V8_INCLUDE})
+  target_link_libraries (${name} ${V8_LIBS} wasm_v8 pthread)
+endfunction(example)
+
+example(hello hello.c)
+example(hello_cpp hello.cc)

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -145,7 +145,7 @@ own wasm_store_t* wasm_store_new(wasm_engine_t*);
 ///////////////////////////////////////////////////////////////////////////////
 // Type Representations
 
-// Tyoe atributes
+// Type attributes
 
 typedef enum wasm_mutability_t {
   WASM_CONST,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -fPIC")
 
-add_library(wasm_v8 STATIC wasm-v8-lowlevel.cc wasm-bin.cc wasm-v8.cc wasm-bin.hh wasm-v8-lowlevel.hh)
+add_library(wasm_v8 SHARED wasm-bin.cc wasm-c.cc wasm-v8.cc wasm-bin.hh)
 target_include_directories(wasm_v8 PRIVATE ${V8_INCLUDE} ${V8V8}/out.gn/x64.release/gen ${V8V8}/src)
 target_link_libraries (wasm_v8 ${V8_LIBS})


### PR DESCRIPTION
Changes:
* Update CMake files for recent changs
* Build a shared library instead of static (should do both or make it configurable)
* Add `hello_twice.c` and `hello_twice.cc` which are like `hello.c` and `hello.cc` but spin up the engine twice. Currently both `segfault` on the second run