### PR TITLE
Fix PATH in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CFLAGS = -ggdb
 CXXFLAGS = ${CFLAGS} -fsanitize=address
 LDFLAGS = -fsanitize-memory-track-origins -fsanitize-memory-use-after-dtor
 
+BASE_DIR = $(realpath $(dir $(realpath $(firstword $(MAKEFILE_LIST)))))
 OUT_DIR = out
 WASM_DIR = .
 EXAMPLE_DIR = example
@@ -25,7 +26,7 @@ WASM_O = ${WASM_LIBS:%=${WASM_OUT}/%.o}
 V8_BUILD = ${V8_ARCH}.${V8_MODE}
 V8_V8 = ${V8_DIR}/v8
 V8_DEPOT_TOOLS = ${V8_DIR}/depot_tools
-V8_PATH = ${V8_DEPOT_TOOLS}:${PATH}
+V8_PATH = ${BASE_DIR}/${V8_DEPOT_TOOLS}:${PATH}
 V8_INCLUDE = ${V8_V8}/include
 V8_SRC = ${V8_V8}/src
 V8_OUT = ${V8_V8}/out.gn/${V8_BUILD}

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ CFLAGS = -ggdb
 CXXFLAGS = ${CFLAGS} -fsanitize=address
 LDFLAGS = -fsanitize-memory-track-origins -fsanitize-memory-use-after-dtor
 
-BASE_DIR = $(realpath $(dir $(realpath $(firstword $(MAKEFILE_LIST)))))
 OUT_DIR = out
 WASM_DIR = .
 EXAMPLE_DIR = example
@@ -26,7 +25,7 @@ WASM_O = ${WASM_LIBS:%=${WASM_OUT}/%.o}
 V8_BUILD = ${V8_ARCH}.${V8_MODE}
 V8_V8 = ${V8_DIR}/v8
 V8_DEPOT_TOOLS = ${V8_DIR}/depot_tools
-V8_PATH = ${BASE_DIR}/${V8_DEPOT_TOOLS}:${PATH}
+V8_PATH = $(abspath ${V8_DEPOT_TOOLS}):${PATH}
 V8_INCLUDE = ${V8_V8}/include
 V8_SRC = ${V8_V8}/src
 V8_OUT = ${V8_V8}/out.gn/${V8_BUILD}


### PR DESCRIPTION
The `PATH` in `v8-checkout` and `v8-update` is not set correctly.

`v8-checkout` executes:
```
cd v8; PATH=v8/depot_tools:${PATH} fetch v8
```
while `v8-update` executes:
```
cd v8/v8; PATH=v8/depot_tools:${PATH} gclient sync
```
In both cases `v8/depot_tools` is not the correct relative path.

This PR sets the location of `depot_tools` to an absolute path which is computed relative to the `Makefile`.