### PR TITLE
Remove struct passing from C API

### DIFF
--- a/example/callback.c
+++ b/example/callback.c
@@ -91,11 +91,10 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* externs[] = {
+  wasm_extern_t* externs[] = {
     wasm_func_as_extern(print_func1), wasm_func_as_extern(print_func2)
   };
-  wasm_extern_vec_t imports;
-  wasm_extern_vec_init_const(&imports, 2, externs);
+  wasm_extern_vec_t imports = { 2, externs };
   own wasm_instance_t* instance = wasm_instance_new(store, module, &imports);
   if (!instance) {
     printf("> Error instantiating module!\n");
@@ -122,8 +121,7 @@ int main(int argc, const char* argv[]) {
   // Call.
   printf("Calling export...\n");
   wasm_val_t vals[] = { wasm_i32_val(3), wasm_i32_val(4) };
-  wasm_val_vec_t args;
-  wasm_val_vec_init(&args, 2, vals);
+  wasm_val_vec_t args = { 2, vals };
   own wasm_result_t result;
   wasm_func_call(run_func, &args, &result);
   if (result.kind != WASM_RETURN) {

--- a/example/hello.c
+++ b/example/hello.c
@@ -55,9 +55,8 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* externs[] = { wasm_func_as_extern(hello_func) };
-  wasm_extern_vec_t imports;
-  wasm_extern_vec_init_const(&imports, 1, externs);
+  wasm_extern_t* externs[] = { wasm_func_as_extern(hello_func) };
+  wasm_extern_vec_t imports = { 1, externs };
   own wasm_instance_t* instance = wasm_instance_new(store, module, &imports);
   if (!instance) {
     printf("> Error instantiating module!\n");
@@ -83,8 +82,7 @@ int main(int argc, const char* argv[]) {
 
   // Call.
   printf("Calling export...\n");
-  wasm_val_vec_t args;
-  wasm_val_vec_init_empty(&args);
+  wasm_val_vec_t args = { 0, NULL };
   own wasm_result_t result;
   wasm_func_call(run_func, &args, &result);
   if (result.kind != WASM_RETURN) {

--- a/example/hello.c
+++ b/example/hello.c
@@ -8,10 +8,10 @@
 #define own
 
 // A function to be called from Wasm code.
-own wasm_result_t hello_callback(wasm_val_vec_t args) {
+void hello_callback(const wasm_val_vec_t* args, own wasm_result_t* result) {
   printf("Calling back...\n");
   printf("> Hello World!\n");
-  return wasm_result_new_empty();
+  wasm_result_new_empty(result);
 }
 
 
@@ -31,19 +31,20 @@ int main(int argc, const char* argv[]) {
   fseek(file, 0L, SEEK_END);
   size_t file_size = ftell(file);
   fseek(file, 0L, SEEK_SET);
-  wasm_byte_vec_t binary = wasm_byte_vec_new_uninitialized(file_size);
+  wasm_byte_vec_t binary;
+  wasm_byte_vec_new_uninitialized(&binary, file_size);
   fread(binary.data, file_size, 1, file);
   fclose(file);
 
   // Compile.
   printf("Compiling module...\n");
-  own wasm_module_t* module = wasm_module_new(store, binary);
+  own wasm_module_t* module = wasm_module_new(store, &binary);
   if (!module) {
     printf("> Error compiling module!\n");
     return 1;
   }
 
-  wasm_byte_vec_delete(binary);
+  wasm_byte_vec_delete(&binary);
 
   // Create external print functions.
   printf("Creating callback...\n");
@@ -54,9 +55,10 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* imports[] = { wasm_func_as_extern(hello_func) };
-  own wasm_instance_t* instance = wasm_instance_new(
-    store, module, wasm_extern_vec_const(1, imports));
+  const wasm_extern_t* externs[] = { wasm_func_as_extern(hello_func) };
+  wasm_extern_vec_t imports;
+  wasm_extern_vec_init_const(&imports, 1, externs);
+  own wasm_instance_t* instance = wasm_instance_new(store, module, &imports);
   if (!instance) {
     printf("> Error instantiating module!\n");
     return 1;
@@ -64,7 +66,8 @@ int main(int argc, const char* argv[]) {
 
   // Extract export.
   printf("Extracting export...\n");
-  own wasm_extern_vec_t exports = wasm_instance_exports(instance);
+  own wasm_extern_vec_t exports;
+  wasm_instance_exports(instance, &exports);
   if (exports.size == 0) {
     printf("> Error accessing exports!\n");
     return 1;
@@ -80,14 +83,17 @@ int main(int argc, const char* argv[]) {
 
   // Call.
   printf("Calling export...\n");
-  own wasm_result_t result = wasm_func_call(run_func, wasm_val_vec_empty());
+  wasm_val_vec_t args;
+  wasm_val_vec_init_empty(&args);
+  own wasm_result_t result;
+  wasm_func_call(run_func, &args, &result);
   if (result.kind != WASM_RETURN) {
     printf("> Error calling function!\n");
     return 1;
   }
 
-  wasm_extern_vec_delete(exports);
-  wasm_result_delete(result);
+  wasm_extern_vec_delete(&exports);
+  wasm_result_delete(&result);
 
   // Shut down.
   printf("Shutting down...\n");

--- a/example/trap.c
+++ b/example/trap.c
@@ -54,9 +54,8 @@ int main(int argc, const char* argv[]) {
 
   // Instantiate.
   printf("Instantiating module...\n");
-  const wasm_extern_t* externs[] = { wasm_func_as_extern(fail_func) };
-  wasm_extern_vec_t imports;
-  wasm_extern_vec_init_const(&imports, 2, externs);
+  wasm_extern_t* externs[] = { wasm_func_as_extern(fail_func) };
+  wasm_extern_vec_t imports = { 2, externs };
   own wasm_instance_t* instance = wasm_instance_new(store, module, &imports);
   if (!instance) {
     printf("> Error instantiating module!\n");
@@ -84,8 +83,7 @@ int main(int argc, const char* argv[]) {
     }
 
     printf("Calling export %d...\n", i);
-    wasm_val_vec_t args;
-    wasm_val_vec_init_empty(&args);
+    wasm_val_vec_t args = { 0, NULL };
     own wasm_result_t result;
     wasm_func_call(func, &args, &result);
     if (result.kind != WASM_TRAP) {

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -166,14 +166,7 @@ typedef struct wasm_limits_t {
   uint32_t max;
 } wasm_limits_t;
 
-static inline wasm_limits_t wasm_limits(uint32_t min, uint32_t max) {
-  wasm_limits_t l = {min, max};
-  return l;
-}
-
-static inline wasm_limits_t wasm_limits_no_max(uint32_t min) {
-  return wasm_limits(min, 0xffffffff);
-}
+static const uint32_t wasm_limits_max_default = 0xffffffff;
 
 
 // Generic

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -72,25 +72,6 @@ typedef double float64_t;
     wasm_##name##_t ptr_or_none* data; \
   } wasm_##name##_vec_t; \
   \
-  static inline void wasm_##name##_vec_init( \
-    wasm_##name##_vec_t* out, \
-    size_t size, wasm_##name##_t ptr_or_none xs[] \
-  ) { \
-    wasm_##name##_vec_t v = {size, xs}; \
-    *out = v; \
-  } \
-  static inline void wasm_##name##_vec_init_const( \
-    wasm_##name##_vec_t* out, \
-    size_t size, const wasm_##name##_t ptr_or_none xs[] \
-  ) { \
-    wasm_##name##_vec_t v = {size, (wasm_##name##_t ptr_or_none*)xs}; \
-    *out = v; \
-  } \
-  \
-  static inline void wasm_##name##_vec_init_empty(wasm_##name##_vec_t* out) { \
-    wasm_##name##_vec_init(out, 0, NULL); \
-  } \
-  \
   void wasm_##name##_vec_new_empty(own wasm_##name##_vec_t* out); \
   void wasm_##name##_vec_new_uninitialized( \
     own wasm_##name##_vec_t* out, size_t); \
@@ -263,17 +244,27 @@ typedef enum wasm_externkind_t {
   WASM_EXTERN_MEMORY
 } wasm_externkind_t;
 
-const wasm_externtype_t* wasm_functype_as_externtype(const wasm_functype_t*);
-const wasm_externtype_t* wasm_globaltype_as_externtype(const wasm_globaltype_t*);
-const wasm_externtype_t* wasm_tabletype_as_externtype(const wasm_tabletype_t*);
-const wasm_externtype_t* wasm_memorytype_as_externtype(const wasm_memorytype_t*);
+wasm_externtype_t* wasm_functype_as_externtype(wasm_functype_t*);
+wasm_externtype_t* wasm_globaltype_as_externtype(wasm_globaltype_t*);
+wasm_externtype_t* wasm_tabletype_as_externtype(wasm_tabletype_t*);
+wasm_externtype_t* wasm_memorytype_as_externtype(wasm_memorytype_t*);
+
+const wasm_externtype_t* wasm_functype_as_externtype_const(const wasm_functype_t*);
+const wasm_externtype_t* wasm_globaltype_as_externtype_const(const wasm_globaltype_t*);
+const wasm_externtype_t* wasm_tabletype_as_externtype_const(const wasm_tabletype_t*);
+const wasm_externtype_t* wasm_memorytype_as_externtype_const(const wasm_memorytype_t*);
 
 wasm_externkind_t wasm_externtype_kind(const wasm_externtype_t*);
 
-const wasm_functype_t* wasm_externtype_as_functype(const wasm_externtype_t*);
-const wasm_globaltype_t* wasm_externtype_as_globaltype(const wasm_externtype_t*);
-const wasm_tabletype_t* wasm_externtype_as_tabletype(const wasm_externtype_t*);
-const wasm_memorytype_t* wasm_externtype_as_memorytype(const wasm_externtype_t*);
+wasm_functype_t* wasm_externtype_as_functype(wasm_externtype_t*);
+wasm_globaltype_t* wasm_externtype_as_globaltype(wasm_externtype_t*);
+wasm_tabletype_t* wasm_externtype_as_tabletype(wasm_externtype_t*);
+wasm_memorytype_t* wasm_externtype_as_memorytype(wasm_externtype_t*);
+
+const wasm_functype_t* wasm_externtype_as_functype_const(const wasm_externtype_t*);
+const wasm_globaltype_t* wasm_externtype_as_globaltype_const(const wasm_externtype_t*);
+const wasm_tabletype_t* wasm_externtype_as_tabletype_const(const wasm_externtype_t*);
+const wasm_memorytype_t* wasm_externtype_as_memorytype_const(const wasm_externtype_t*);
 
 
 // Import Types
@@ -492,17 +483,27 @@ wasm_memory_pages_t wasm_memory_grow(wasm_memory_t*, wasm_memory_pages_t delta);
 WASM_DECLARE_REF(extern)
 WASM_DECLARE_VEC(extern, *)
 
-const wasm_extern_t* wasm_func_as_extern(const wasm_func_t*);
-const wasm_extern_t* wasm_global_as_extern(const wasm_global_t*);
-const wasm_extern_t* wasm_table_as_extern(const wasm_table_t*);
-const wasm_extern_t* wasm_memory_as_extern(const wasm_memory_t*);
+wasm_extern_t* wasm_func_as_extern(wasm_func_t*);
+wasm_extern_t* wasm_global_as_extern(wasm_global_t*);
+wasm_extern_t* wasm_table_as_extern(wasm_table_t*);
+wasm_extern_t* wasm_memory_as_extern(wasm_memory_t*);
+
+const wasm_extern_t* wasm_func_as_extern_const(const wasm_func_t*);
+const wasm_extern_t* wasm_global_as_extern_const(const wasm_global_t*);
+const wasm_extern_t* wasm_table_as_extern_const(const wasm_table_t*);
+const wasm_extern_t* wasm_memory_as_extern_const(const wasm_memory_t*);
 
 wasm_externkind_t wasm_extern_kind(const wasm_extern_t*);
 
-const wasm_func_t* wasm_extern_as_func(const wasm_extern_t*);
-const wasm_global_t* wasm_extern_as_global(const wasm_extern_t*);
-const wasm_table_t* wasm_extern_as_table(const wasm_extern_t*);
-const wasm_memory_t* wasm_extern_as_memory(const wasm_extern_t*);
+wasm_func_t* wasm_extern_as_func(wasm_extern_t*);
+wasm_global_t* wasm_extern_as_global(wasm_extern_t*);
+wasm_table_t* wasm_extern_as_table(wasm_extern_t*);
+wasm_memory_t* wasm_extern_as_memory(wasm_extern_t*);
+
+const wasm_func_t* wasm_extern_as_func_const(const wasm_extern_t*);
+const wasm_global_t* wasm_extern_as_global_const(const wasm_extern_t*);
+const wasm_table_t* wasm_extern_as_table_const(const wasm_extern_t*);
+const wasm_memory_t* wasm_extern_as_memory_const(const wasm_extern_t*);
 
 
 // Module Instances

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -193,7 +193,7 @@ typedef enum wasm_valkind_t {
 
 own wasm_valtype_t* wasm_valtype_new(wasm_valkind_t);
 
-wasm_valkind_t wasm_valtype_kind(wasm_valtype_t*);
+wasm_valkind_t wasm_valtype_kind(const wasm_valtype_t*);
 
 static inline bool wasm_valkind_is_num(wasm_valkind_t k) {
   return k < WASM_ANYREF_VAL;
@@ -202,10 +202,10 @@ static inline bool wasm_valkind_is_ref(wasm_valkind_t k) {
   return k >= WASM_ANYREF_VAL;
 }
 
-static inline bool wasm_valtype_is_num(wasm_valtype_t* t) {
+static inline bool wasm_valtype_is_num(const wasm_valtype_t* t) {
   return wasm_valkind_is_num(wasm_valtype_kind(t));
 }
-static inline bool wasm_valtype_is_ref(wasm_valtype_t* t) {
+static inline bool wasm_valtype_is_ref(const wasm_valtype_t* t) {
   return wasm_valkind_is_ref(wasm_valtype_kind(t));
 }
 

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -363,7 +363,7 @@ public:
   auto copy() const -> own<TableType*>;
 
   auto element() const -> const own<ValType*>&;
-  auto limits() const -> Limits;
+  auto limits() const -> const Limits&;
 };
 
 
@@ -377,7 +377,7 @@ public:
   static auto make(Limits) -> own<MemoryType*>;
   auto copy() const -> own<MemoryType*>;
 
-  auto limits() const -> Limits;
+  auto limits() const -> const Limits&;
 };
 
 

--- a/src/wasm-c.cc
+++ b/src/wasm-c.cc
@@ -333,7 +333,7 @@ wasm_valtype_t* wasm_valtype_new(wasm_valkind_t k) {
   return release(ValType::make(reveal(k)));
 }
 
-wasm_valkind_t wasm_valtype_kind(wasm_valtype_t* t) {
+wasm_valkind_t wasm_valtype_kind(const wasm_valtype_t* t) {
   return hide(t->kind());
 }
 

--- a/src/wasm-c.cc
+++ b/src/wasm-c.cc
@@ -126,21 +126,18 @@ struct borrowed_vec {
   } \
   extern "C++" inline auto get(vec<Name ptr_or_none>& v) \
   -> wasm_##name##_vec_t { \
-    wasm_##name##_vec_t v2; \
-    wasm_##name##_vec_init(&v2, v.size(), hide(v.get())); \
+    wasm_##name##_vec_t v2 = { v.size(), hide(v.get()) }; \
     return v2; \
   } \
   extern "C++" inline auto get(const vec<Name ptr_or_none>& v) \
   -> const wasm_##name##_vec_t { \
-    wasm_##name##_vec_t v2; \
-    wasm_##name##_vec_init(&v2, \
-      v.size(), const_cast<wasm_##name##_t ptr_or_none*>(hide(v.get()))); \
+    wasm_##name##_vec_t v2 = { \
+      v.size(), const_cast<wasm_##name##_t ptr_or_none*>(hide(v.get())) }; \
     return v2; \
   } \
   extern "C++" inline auto release(vec<Name ptr_or_none>&& v) \
   -> wasm_##name##_vec_t { \
-    wasm_##name##_vec_t v2; \
-    wasm_##name##_vec_init(&v2, v.size(), hide(v.release())); \
+    wasm_##name##_vec_t v2 = { v.size(), hide(v.release()) }; \
     return v2; \
   } \
   extern "C++" inline auto adopt(wasm_##name##_vec_t* v) \
@@ -412,46 +409,76 @@ const wasm_limits_t* wasm_memorytype_limits(const wasm_memorytype_t* mt) {
 
 WASM_DEFINE_TYPE(externtype, ExternType)
 
-const wasm_externtype_t* wasm_functype_as_externtype(
+wasm_externtype_t* wasm_functype_as_externtype(wasm_functype_t* ft) {
+  return hide(static_cast<ExternType*>(ft));
+}
+wasm_externtype_t* wasm_globaltype_as_externtype(wasm_globaltype_t* gt) {
+  return hide(static_cast<ExternType*>(gt));
+}
+wasm_externtype_t* wasm_tabletype_as_externtype(wasm_tabletype_t* tt) {
+  return hide(static_cast<ExternType*>(tt));
+}
+wasm_externtype_t* wasm_memorytype_as_externtype(wasm_memorytype_t* mt) {
+  return hide(static_cast<ExternType*>(mt));
+}
+
+const wasm_externtype_t* wasm_functype_as_externtype_const(
   const wasm_functype_t* ft
 ) {
   return hide(static_cast<const ExternType*>(ft));
 }
-const wasm_externtype_t* wasm_globaltype_as_externtype(
+const wasm_externtype_t* wasm_globaltype_as_externtype_const(
   const wasm_globaltype_t* gt
 ) {
   return hide(static_cast<const ExternType*>(gt));
 }
-const wasm_externtype_t* wasm_tabletype_as_externtype(
+const wasm_externtype_t* wasm_tabletype_as_externtype_const(
   const wasm_tabletype_t* tt
 ) {
   return hide(static_cast<const ExternType*>(tt));
 }
-const wasm_externtype_t* wasm_memorytype_as_externtype(
+const wasm_externtype_t* wasm_memorytype_as_externtype_const(
   const wasm_memorytype_t* mt
 ) {
   return hide(static_cast<const ExternType*>(mt));
 }
 
-const wasm_functype_t* wasm_externtype_as_functype(
+wasm_functype_t* wasm_externtype_as_functype(wasm_externtype_t* et) {
+  return et->kind() == EXTERN_FUNC
+    ? hide(static_cast<FuncType*>(reveal(et))) : nullptr;
+}
+wasm_globaltype_t* wasm_externtype_as_globaltype(wasm_externtype_t* et) {
+  return et->kind() == EXTERN_GLOBAL
+    ? hide(static_cast<GlobalType*>(reveal(et))) : nullptr;
+}
+wasm_tabletype_t* wasm_externtype_as_tabletype(wasm_externtype_t* et) {
+  return et->kind() == EXTERN_TABLE
+    ? hide(static_cast<TableType*>(reveal(et))) : nullptr;
+}
+wasm_memorytype_t* wasm_externtype_as_memorytype(wasm_externtype_t* et) {
+  return et->kind() == EXTERN_MEMORY
+    ? hide(static_cast<MemoryType*>(reveal(et))) : nullptr;
+}
+
+const wasm_functype_t* wasm_externtype_as_functype_const(
   const wasm_externtype_t* et
 ) {
   return et->kind() == EXTERN_FUNC
     ? hide(static_cast<const FuncType*>(reveal(et))) : nullptr;
 }
-const wasm_globaltype_t* wasm_externtype_as_globaltype(
+const wasm_globaltype_t* wasm_externtype_as_globaltype_const(
   const wasm_externtype_t* et
 ) {
   return et->kind() == EXTERN_GLOBAL
     ? hide(static_cast<const GlobalType*>(reveal(et))) : nullptr;
 }
-const wasm_tabletype_t* wasm_externtype_as_tabletype(
+const wasm_tabletype_t* wasm_externtype_as_tabletype_const(
   const wasm_externtype_t* et
 ) {
   return et->kind() == EXTERN_TABLE
     ? hide(static_cast<const TableType*>(reveal(et))) : nullptr;
 }
-const wasm_memorytype_t* wasm_externtype_as_memorytype(
+const wasm_memorytype_t* wasm_externtype_as_memorytype_const(
   const wasm_externtype_t* et
 ) {
   return et->kind() == EXTERN_MEMORY
@@ -908,34 +935,60 @@ wasm_memory_pages_t wasm_memory_grow(
 WASM_DEFINE_REF(extern, Extern)
 WASM_DEFINE_VEC(extern, Extern, *)
 
-const wasm_extern_t* wasm_func_as_extern(const wasm_func_t* func) {
+wasm_extern_t* wasm_func_as_extern(wasm_func_t* func) {
+  return hide(static_cast<Extern*>(reveal(func)));
+}
+wasm_extern_t* wasm_global_as_extern(wasm_global_t* global) {
+  return hide(static_cast<Extern*>(reveal(global)));
+}
+wasm_extern_t* wasm_table_as_extern(wasm_table_t* table) {
+  return hide(static_cast<Extern*>(reveal(table)));
+}
+wasm_extern_t* wasm_memory_as_extern(wasm_memory_t* memory) {
+  return hide(static_cast<Extern*>(reveal(memory)));
+}
+
+const wasm_extern_t* wasm_func_as_extern_const(const wasm_func_t* func) {
   return hide(static_cast<const Extern*>(reveal(func)));
 }
-const wasm_extern_t* wasm_global_as_extern(const wasm_global_t* global) {
+const wasm_extern_t* wasm_global_as_extern_const(const wasm_global_t* global) {
   return hide(static_cast<const Extern*>(reveal(global)));
 }
-const wasm_extern_t* wasm_table_as_extern(const wasm_table_t* table) {
+const wasm_extern_t* wasm_table_as_extern_const(const wasm_table_t* table) {
   return hide(static_cast<const Extern*>(reveal(table)));
 }
-const wasm_extern_t* wasm_memory_as_extern(const wasm_memory_t* memory) {
+const wasm_extern_t* wasm_memory_as_extern_const(const wasm_memory_t* memory) {
   return hide(static_cast<const Extern*>(reveal(memory)));
+}
+
+wasm_func_t* wasm_extern_as_func(wasm_extern_t* external) {
+  return hide(external->func());
+}
+wasm_global_t* wasm_extern_as_global(wasm_extern_t* external) {
+  return hide(external->global());
+}
+wasm_table_t* wasm_extern_as_table(wasm_extern_t* external) {
+  return hide(external->table());
+}
+wasm_memory_t* wasm_extern_as_memory(wasm_extern_t* external) {
+  return hide(external->memory());
+}
+
+const wasm_func_t* wasm_extern_as_func_const(const wasm_extern_t* external) {
+  return hide(external->func());
+}
+const wasm_global_t* wasm_extern_as_global_const(const wasm_extern_t* external) {
+  return hide(external->global());
+}
+const wasm_table_t* wasm_extern_as_table_const(const wasm_extern_t* external) {
+  return hide(external->table());
+}
+const wasm_memory_t* wasm_extern_as_memory_const(const wasm_extern_t* external) {
+  return hide(external->memory());
 }
 
 wasm_externkind_t wasm_extern_kind(const wasm_extern_t* external) {
   return hide(external->kind());
-}
-
-const wasm_func_t* wasm_extern_as_func(const wasm_extern_t* external) {
-  return hide(external->func());
-}
-const wasm_global_t* wasm_extern_as_global(const wasm_extern_t* external) {
-  return hide(external->global());
-}
-const wasm_table_t* wasm_extern_as_table(const wasm_extern_t* external) {
-  return hide(external->table());
-}
-const wasm_memory_t* wasm_extern_as_memory(const wasm_extern_t* external) {
-  return hide(external->memory());
 }
 
 

--- a/src/wasm-v8.cc
+++ b/src/wasm-v8.cc
@@ -484,7 +484,7 @@ auto TableType::element() const -> const own<ValType*>& {
   return impl(this)->element;
 }
 
-auto TableType::limits() const -> Limits {
+auto TableType::limits() const -> const Limits& {
   return impl(this)->limits;
 }
 
@@ -525,7 +525,7 @@ auto MemoryType::copy() const -> own<MemoryType*> {
   return MemoryType::make(limits());
 }
 
-auto MemoryType::limits() const -> Limits {
+auto MemoryType::limits() const -> const Limits& {
   return impl(this)->limits;
 }
 


### PR DESCRIPTION
* Struct passing makes it harder for some bindings, so avoid it in favour of passing pointers.
* Some more const correctness.