### PR TITLE
Change default V8 version to 6.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ EXAMPLE_DIR = example
 EXAMPLE_OUT = ${OUT_DIR}/${EXAMPLE_DIR}
 EXAMPLES = hello callback trap reflect
 
-V8_VERSION = master  # or e.g. branch-heads/6.3
+V8_VERSION = branch-heads/6.8
 V8_ARCH = x64
 V8_MODE = release
 V8_DIR = v8


### PR DESCRIPTION
I couldn't get `master` V8 branch working. When I build it some library objects are missing:
```
# ls v8/v8/out.gn/x64.release/obj/libv8*
../v8/v8/out.gn/x64.release/obj/libv8_libbase.a
../v8/v8/out.gn/x64.release/obj/libv8_libplatform.a
```
I had no issues building from `6.8` branch though.

Would be better to set the default to something stable.