### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:bionic
 RUN apt-get update && apt-get install -y \
     apt-utils \
+    clang \
     cmake \
     curl \
     git \
@@ -12,5 +13,5 @@ RUN apt-get update && apt-get install -y \
     python
 ADD . /code
 WORKDIR /code
-RUN make v8-checkout && make -j v8
+RUN V8_VERSION="branch-heads/6.8" make v8-checkout && make -j v8
 RUN mkdir build && cd build && cmake .. && make

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:bionic
+RUN apt-get update && apt-get install -y \
+    apt-utils \
+    cmake \
+    curl \
+    git \
+    libc++-dev \
+    libc++abi-dev \
+    libglib2.0-dev \
+    libgmp-dev \
+    ninja-build \
+    python
+ADD . /code
+WORKDIR /code
+RUN make v8-checkout && make -j v8

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,10 @@ RUN apt-get update && apt-get install -y \
     libgmp-dev \
     ninja-build \
     python
-ADD . /code
-WORKDIR /code
+ADD . /code/wasm-c-api
+WORKDIR /code/wasm-c-api
 RUN make V8_VERSION="branch-heads/6.8" v8-checkout && make -j v8
-WORKDIR /code/v8/v8
+WORKDIR /code/wasm-c-api/v8/v8
 RUN touch out.gn/x64.release/args.gn && ninja -C out.gn/x64.release
-WORKDIR /code
+WORKDIR /code/wasm-c-api
 RUN mkdir build && cd build && cmake .. && make

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,4 @@ RUN apt-get update && apt-get install -y \
 ADD . /code
 WORKDIR /code
 RUN make v8-checkout && make -j v8
+RUN mkdir build && cd build && cmake .. && make

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,7 @@ RUN apt-get update && apt-get install -y \
 ADD . /code
 WORKDIR /code
 RUN make V8_VERSION="branch-heads/6.8" v8-checkout && make -j v8
+WORKDIR /code/v8/v8
+RUN touch out.gn/x64.release/args.gn && ninja -C out.gn/x64.release
+WORKDIR /code
 RUN mkdir build && cd build && cmake .. && make

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN apt-get update && apt-get install -y \
     python
 ADD . /code
 WORKDIR /code
-RUN V8_VERSION="branch-heads/6.8" make v8-checkout && make -j v8
+RUN make V8_VERSION="branch-heads/6.8" v8-checkout && make -j v8
 RUN mkdir build && cd build && cmake .. && make


### PR DESCRIPTION
This PR adds a `Dockerfile` that demonstrates how to build V8 and the WASM library.

Not sure why but I couldn't build all of the object files for the static library without this:
```
touch out.gn/x64.release/args.gn && ninja -C out.gn/x64.release
```
The first time `ninja -C out.gn/x64.release` runs only some object files are built. Need to run it again to get them all. `¯\_(ツ)_/¯`
