### PR TITLE
Change wasm_engine_new interface

### DIFF
--- a/example/callback.c
+++ b/example/callback.c
@@ -52,7 +52,7 @@ void print_callback(const wasm_val_vec_t* args, own wasm_result_t* result) {
 int main(int argc, const char* argv[]) {
   // Initialize.
   printf("Initializing...\n");
-  wasm_engine_t* engine = wasm_engine_new(argc, argv);
+  wasm_engine_t* engine = wasm_engine_new(argv[0]);
   wasm_store_t* store = wasm_store_new(engine);
 
   // Load binary.

--- a/example/callback.cc
+++ b/example/callback.cc
@@ -49,7 +49,7 @@ auto print_callback(const wasm::vec<wasm::Val>& args) -> wasm::Result {
 void run(int argc, const char* argv[]) {
   // Initialize.
   std::cout << "Initializing..." << std::endl;
-  auto engine = wasm::Engine::make(argc, argv);
+  auto engine = wasm::Engine::make(argv[0]);
   auto store = wasm::Store::make(engine);
 
   // Load binary.

--- a/example/global.c
+++ b/example/global.c
@@ -10,7 +10,7 @@
 int main(int argc, const char* argv[]) {
   // Initialize.
   printf("Initializing...\n");
-  wasm_engine_t* engine = wasm_engine_new(argc, argv);
+  wasm_engine_t* engine = wasm_engine_new(argv[0]);
   wasm_store_t* store = wasm_store_new(engine);
 
   // Load binary.

--- a/example/global.cc
+++ b/example/global.cc
@@ -51,7 +51,7 @@ void check(T actual, U expected) {
 void run(int argc, const char* argv[]) {
   // Initialize.
   std::cout << "Initializing..." << std::endl;
-  auto engine = wasm::Engine::make(argc, argv);
+  auto engine = wasm::Engine::make(argv[0]);
   auto store = wasm::Store::make(engine);
 
   // Load binary.

--- a/example/hello.c
+++ b/example/hello.c
@@ -18,7 +18,7 @@ void hello_callback(const wasm_val_vec_t* args, own wasm_result_t* result) {
 int main(int argc, const char* argv[]) {
   // Initialize.
   printf("Initializing...\n");
-  wasm_engine_t* engine = wasm_engine_new(argc, argv);
+  wasm_engine_t* engine = wasm_engine_new(argv[0]);
   wasm_store_t* store = wasm_store_new(engine);
 
   // Load binary.

--- a/example/hello.cc
+++ b/example/hello.cc
@@ -18,7 +18,7 @@ auto hello_callback(const wasm::vec<wasm::Val>& args) -> wasm::Result {
 void run(int argc, const char* argv[]) {
   // Initialize.
   std::cout << "Initializing..." << std::endl;
-  auto engine = wasm::Engine::make(argc, argv);
+  auto engine = wasm::Engine::make(argv[0]);
   auto store = wasm::Store::make(engine);
 
   // Load binary.

--- a/example/reflect.c
+++ b/example/reflect.c
@@ -81,7 +81,7 @@ void print_name(const wasm_name_t* name) {
 int main(int argc, const char* argv[]) {
   // Initialize.
   printf("Initializing...\n");
-  wasm_engine_t* engine = wasm_engine_new(argc, argv);
+  wasm_engine_t* engine = wasm_engine_new(argv[0]);
   wasm_store_t* store = wasm_store_new(engine);
 
   // Load binary.

--- a/example/reflect.cc
+++ b/example/reflect.cc
@@ -73,7 +73,7 @@ auto operator<<(std::ostream& out, const wasm::Name& name) -> std::ostream& {
 void run(int argc, const char* argv[]) {
   // Initialize.
   std::cout << "Initializing..." << std::endl;
-  auto engine = wasm::Engine::make(argc, argv);
+  auto engine = wasm::Engine::make(argv[0]);
   auto store = wasm::Store::make(engine);
 
   // Load binary.

--- a/example/trap.c
+++ b/example/trap.c
@@ -17,7 +17,7 @@ void fail_callback(const wasm_val_vec_t* args, own wasm_result_t* result) {
 int main(int argc, const char* argv[]) {
   // Initialize.
   printf("Initializing...\n");
-  wasm_engine_t* engine = wasm_engine_new(argc, argv);
+  wasm_engine_t* engine = wasm_engine_new(argv[0]);
   wasm_store_t* store = wasm_store_new(engine);
 
   // Load binary.

--- a/example/trap.cc
+++ b/example/trap.cc
@@ -16,7 +16,7 @@ auto fail_callback(const wasm::vec<wasm::Val>& args) -> wasm::Result {
 void run(int argc, const char* argv[]) {
   // Initialize.
   std::cout << "Initializing..." << std::endl;
-  auto engine = wasm::Engine::make(argc, argv);
+  auto engine = wasm::Engine::make(argv[0]);
   auto store = wasm::Store::make(engine);
 
   // Load binary.

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -120,9 +120,9 @@ own wasm_config_t* wasm_config_new();
 
 WASM_DECLARE_OWN(engine)
 
-own wasm_engine_t* wasm_engine_new(int argc, const char* const argv[]);
+own wasm_engine_t* wasm_engine_new(const char* directory_path);
 own wasm_engine_t* wasm_engine_new_with_config(
-  int argc, const char* const argv[], own wasm_config_t*);
+  const char* directory_path, own wasm_config_t*);
 
 
 // Store

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -229,7 +229,7 @@ public:
   void operator delete(void*);
 
   static auto make(
-    int argc, const char* const argv[], own<Config*>&& = Config::make()
+    const char* directory_path, own<Config*>&& = Config::make()
   ) -> own<Engine*>;
 };
 

--- a/src/wasm-c.cc
+++ b/src/wasm-c.cc
@@ -248,14 +248,14 @@ wasm_config_t* wasm_config_new() {
 
 WASM_DEFINE_OWN(engine, Engine)
 
-wasm_engine_t* wasm_engine_new(int argc, const char *const argv[]) {
-  return release(Engine::make(argc, argv));
+wasm_engine_t* wasm_engine_new(const char* directory_path) {
+  return release(Engine::make(directory_path));
 }
 
 wasm_engine_t* wasm_engine_new_with_config(
-  int argc, const char *const argv[], wasm_config_t* config
+  const char* directory_path, wasm_config_t* config
 ) {
-  return release(Engine::make(argc, argv, adopt(config)));
+  return release(Engine::make(directory_path, adopt(config)));
 }
 
 

--- a/src/wasm-v8.cc
+++ b/src/wasm-v8.cc
@@ -101,12 +101,12 @@ void Engine::operator delete(void *p) {
 }
 
 auto Engine::make(
-  int argc, const char *const argv[], own<Config*>&& config
+  const char* directory_path, own<Config*>&& config
 ) -> own<Engine*> {
   v8::internal::FLAG_experimental_wasm_mut_global = true;
   auto engine = make_own(seal<Engine>(new(std::nothrow) EngineImpl));
   if (!engine) return engine;
-  v8::V8::InitializeExternalStartupData(argv[0]);
+  v8::V8::InitializeExternalStartupData(directory_path);
   static std::unique_ptr<v8::Platform> platform =
     v8::platform::NewDefaultPlatform();
   v8::V8::InitializePlatform(platform.get());


### PR DESCRIPTION
`wasm_engine_new` has a strange interface:
```
own wasm_engine_t* wasm_engine_new(int argc, const char* const argv[]);
```
Passing `argc` and `argv` looks unnecessary. After all only `argv[0]` is used:
```
auto Engine::make(
  int argc, const char *const argv[], own<Config*>&& config
) -> own<Engine*> {
  ...
  v8::V8::InitializeExternalStartupData(argv[0]);
  ...
}
```
And all we need is the directory path:
```
void v8::V8::InitializeExternalStartupData(const char* directory_path)
```
This PR changes `wasm_engine_new` to:
```
own wasm_engine_t* wasm_engine_new(const char* directory_path)
```