### PR TITLE
Fix borrowed_val destructor

### DIFF
--- a/src/wasm-c.cc
+++ b/src/wasm-c.cc
@@ -620,7 +620,11 @@ struct borrowed_val {
   Val it;
   borrowed_val(Val&& v) : it(std::move(v)) {}
   borrowed_val(borrowed_val&& that) : it(std::move(that.it)) {}
-  ~borrowed_val() { it.release_ref(); }
+  ~borrowed_val() {
+    if(is_ref(it.kind())) {
+      it.release_ref();
+    }
+  }
 };
 
 inline auto borrow(const wasm_val_t* v) -> borrowed_val {


### PR DESCRIPTION
Only call `release_ref` when `Val` is a ref. Otherwise we'll get an error:
```
wasm.hh:495: own<wasm::Ref *> wasm::Val::release_ref(): Assertion `is_ref(kind_)' failed.
```
when, for instance, instantiating a global:
```
wasm_val_t g = { .kind = WASM_I32 };
g.of.i32 = 12345;

wasm_extern_t* externs[] = {
  wasm_global_as_extern(
    wasm_global_new(
      store,
      wasm_globaltype_new(wasm_valtype_new_i32(), WASM_CONST),
      &g
    )
  ),
};
```