### PR TITLE
Create monolithic V8 library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,6 @@ RUN apt-get update && apt-get install -y \
     python
 ADD . /code/wasm-c-api
 WORKDIR /code/wasm-c-api
-RUN make v8-checkout && make -j v8
-RUN make C_COMP=gcc LD_FLAGS= C_FLAGS= 
+RUN make v8-checkout
+RUN make -j v8
+RUN make


### PR DESCRIPTION
* Build monolithic V8 library.
* Drop ICU and inspector support, which are useless for Wasm.
* Link blobs.
* Change Dockerfile to use clang, which now should work.