### PR TITLE
Drop argv parameters from Engine::make

### DIFF
--- a/example/callback.c
+++ b/example/callback.c
@@ -65,7 +65,7 @@ void closure_callback(void* env, const wasm_val_vec_t* args, own wasm_result_t* 
 int main(int argc, const char* argv[]) {
   // Initialize.
   printf("Initializing...\n");
-  wasm_engine_t* engine = wasm_engine_new(argc, argv);
+  wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
 
   // Load binary.

--- a/example/callback.cc
+++ b/example/callback.cc
@@ -55,10 +55,10 @@ auto closure_callback(void* env, const wasm::vec<wasm::Val>& args) -> wasm::Resu
 }
 
 
-void run(int argc, const char* argv[]) {
+void run() {
   // Initialize.
   std::cout << "Initializing..." << std::endl;
-  auto engine = wasm::Engine::make(argc, argv);
+  auto engine = wasm::Engine::make();
   auto store_ = wasm::Store::make(engine.get());
   auto store = store_.get();
 
@@ -145,7 +145,7 @@ void run(int argc, const char* argv[]) {
 
 
 int main(int argc, const char* argv[]) {
-  run(argc, argv);
+  run();
   std::cout << "Done." << std::endl;
   return 0;
 }

--- a/example/global.c
+++ b/example/global.c
@@ -10,7 +10,7 @@
 int main(int argc, const char* argv[]) {
   // Initialize.
   printf("Initializing...\n");
-  wasm_engine_t* engine = wasm_engine_new(argc, argv);
+  wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
 
   // Load binary.

--- a/example/global.cc
+++ b/example/global.cc
@@ -40,10 +40,10 @@ void check(T actual, U expected) {
   }
 }
 
-void run(int argc, const char* argv[]) {
+void run() {
   // Initialize.
   std::cout << "Initializing..." << std::endl;
-  auto engine = wasm::Engine::make(argc, argv);
+  auto engine = wasm::Engine::make();
   auto store_ = wasm::Store::make(engine.get());
   auto store = store_.get();
 
@@ -177,7 +177,7 @@ void run(int argc, const char* argv[]) {
 
 
 int main(int argc, const char* argv[]) {
-  run(argc, argv);
+  run();
   std::cout << "Done." << std::endl;
   return 0;
 }

--- a/example/hello.c
+++ b/example/hello.c
@@ -18,7 +18,7 @@ void hello_callback(const wasm_val_vec_t* args, own wasm_result_t* result) {
 int main(int argc, const char* argv[]) {
   // Initialize.
   printf("Initializing...\n");
-  wasm_engine_t* engine = wasm_engine_new(argc, argv);
+  wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
 
   // Load binary.

--- a/example/hello.cc
+++ b/example/hello.cc
@@ -15,10 +15,10 @@ auto hello_callback(const wasm::vec<wasm::Val>& args) -> wasm::Result {
 }
 
 
-void run(int argc, const char* argv[]) {
+void run() {
   // Initialize.
   std::cout << "Initializing..." << std::endl;
-  auto engine = wasm::Engine::make(argc, argv);
+  auto engine = wasm::Engine::make();
   auto store_ = wasm::Store::make(engine.get());
   auto store = store_.get();
 
@@ -79,7 +79,7 @@ void run(int argc, const char* argv[]) {
 
 
 int main(int argc, const char* argv[]) {
-  run(argc, argv);
+  run();
   std::cout << "Done." << std::endl;
   return 0;
 }

--- a/example/memory.c
+++ b/example/memory.c
@@ -10,7 +10,7 @@
 int main(int argc, const char* argv[]) {
   // Initialize.
   printf("Initializing...\n");
-  wasm_engine_t* engine = wasm_engine_new(argc, argv);
+  wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
 
   // Load binary.

--- a/example/memory.cc
+++ b/example/memory.cc
@@ -52,10 +52,10 @@ void check(bool success) {
   }
 }
 
-void run(int argc, const char* argv[]) {
+void run() {
   // Initialize.
   std::cout << "Initializing..." << std::endl;
-  auto engine = wasm::Engine::make(argc, argv);
+  auto engine = wasm::Engine::make();
   auto store_ = wasm::Store::make(engine.get());
   auto store = store_.get();
 
@@ -142,7 +142,7 @@ void run(int argc, const char* argv[]) {
 
 
 int main(int argc, const char* argv[]) {
-  run(argc, argv);
+  run();
   std::cout << "Done." << std::endl;
   return 0;
 }

--- a/example/reflect.c
+++ b/example/reflect.c
@@ -81,7 +81,7 @@ void print_name(const wasm_name_t* name) {
 int main(int argc, const char* argv[]) {
   // Initialize.
   printf("Initializing...\n");
-  wasm_engine_t* engine = wasm_engine_new(argc, argv);
+  wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
 
   // Load binary.

--- a/example/reflect.cc
+++ b/example/reflect.cc
@@ -70,10 +70,10 @@ auto operator<<(std::ostream& out, const wasm::Name& name) -> std::ostream& {
 }
 
 
-void run(int argc, const char* argv[]) {
+void run() {
   // Initialize.
   std::cout << "Initializing..." << std::endl;
-  auto engine = wasm::Engine::make(argc, argv);
+  auto engine = wasm::Engine::make();
   auto store_ = wasm::Store::make(engine.get());
   auto store = store_.get();
 
@@ -127,7 +127,7 @@ void run(int argc, const char* argv[]) {
 
 
 int main(int argc, const char* argv[]) {
-  run(argc, argv);
+  run();
   std::cout << "Done." << std::endl;
   return 0;
 }

--- a/example/serialize.c
+++ b/example/serialize.c
@@ -18,7 +18,7 @@ void hello_callback(const wasm_val_vec_t* args, own wasm_result_t* result) {
 int main(int argc, const char* argv[]) {
   // Initialize.
   printf("Initializing...\n");
-  wasm_engine_t* engine = wasm_engine_new(argc, argv);
+  wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
 
   // Load binary.

--- a/example/serialize.cc
+++ b/example/serialize.cc
@@ -15,10 +15,10 @@ auto hello_callback(const wasm::vec<wasm::Val>& args) -> wasm::Result {
 }
 
 
-void run(int argc, const char* argv[]) {
+void run() {
   // Initialize.
   std::cout << "Initializing..." << std::endl;
-  auto engine = wasm::Engine::make(argc, argv);
+  auto engine = wasm::Engine::make();
   auto store_ = wasm::Store::make(engine.get());
   auto store = store_.get();
 
@@ -91,7 +91,7 @@ void run(int argc, const char* argv[]) {
 
 
 int main(int argc, const char* argv[]) {
-  run(argc, argv);
+  run();
   std::cout << "Done." << std::endl;
   return 0;
 }

--- a/example/table.c
+++ b/example/table.c
@@ -10,7 +10,7 @@
 int main(int argc, const char* argv[]) {
   // Initialize.
   printf("Initializing...\n");
-  wasm_engine_t* engine = wasm_engine_new(argc, argv);
+  wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
 
   // Load binary.

--- a/example/table.cc
+++ b/example/table.cc
@@ -52,10 +52,10 @@ void check(bool success) {
   }
 }
 
-void run(int argc, const char* argv[]) {
+void run() {
   // Initialize.
   std::cout << "Initializing..." << std::endl;
-  auto engine = wasm::Engine::make(argc, argv);
+  auto engine = wasm::Engine::make();
   auto store_ = wasm::Store::make(engine.get());
   auto store = store_.get();
 
@@ -141,7 +141,7 @@ void run(int argc, const char* argv[]) {
 
 
 int main(int argc, const char* argv[]) {
-  run(argc, argv);
+  run();
   std::cout << "Done." << std::endl;
   return 0;
 }

--- a/example/threads.c
+++ b/example/threads.c
@@ -105,7 +105,7 @@ void* run(void* args_abs) {
 
 int main(int argc, const char *argv[]) {
   // Initialize.
-  wasm_engine_t* engine = wasm_engine_new(argc, argv);
+  wasm_engine_t* engine = wasm_engine_new();
 
   // Load binary.
   FILE* file = fopen("threads.wasm", "r");

--- a/example/trap.c
+++ b/example/trap.c
@@ -21,7 +21,7 @@ void fail_callback(void* env, const wasm_val_vec_t* args, own wasm_result_t* res
 int main(int argc, const char* argv[]) {
   // Initialize.
   printf("Initializing...\n");
-  wasm_engine_t* engine = wasm_engine_new(argc, argv);
+  wasm_engine_t* engine = wasm_engine_new();
   wasm_store_t* store = wasm_store_new(engine);
 
   // Load binary.

--- a/example/trap.cc
+++ b/example/trap.cc
@@ -15,10 +15,10 @@ auto fail_callback(void* env, const wasm::vec<wasm::Val>& args) -> wasm::Result 
 }
 
 
-void run(int argc, const char* argv[]) {
+void run() {
   // Initialize.
   std::cout << "Initializing..." << std::endl;
-  auto engine = wasm::Engine::make(argc, argv);
+  auto engine = wasm::Engine::make();
   auto store_ = wasm::Store::make(engine.get());
   auto store = store_.get();
 
@@ -91,7 +91,7 @@ void run(int argc, const char* argv[]) {
 
 
 int main(int argc, const char* argv[]) {
-  run(argc, argv);
+  run();
   std::cout << "Done." << std::endl;
   return 0;
 }

--- a/include/wasm.h
+++ b/include/wasm.h
@@ -120,9 +120,8 @@ own wasm_config_t* wasm_config_new();
 
 WASM_DECLARE_OWN(engine)
 
-own wasm_engine_t* wasm_engine_new(int argc, const char* const argv[]);
-own wasm_engine_t* wasm_engine_new_with_config(
-  int argc, const char* const argv[], own wasm_config_t*);
+own wasm_engine_t* wasm_engine_new();
+own wasm_engine_t* wasm_engine_new_with_config(own wasm_config_t*);
 
 
 // Store

--- a/include/wasm.hh
+++ b/include/wasm.hh
@@ -249,9 +249,7 @@ public:
   ~Engine();
   void operator delete(void*);
 
-  static auto make(
-    int argc, const char* const argv[], own<Config*>&& = Config::make()
-  ) -> own<Engine*>;
+  static auto make(own<Config*>&& = Config::make()) -> own<Engine*>;
 };
 
 

--- a/src/wasm-c.cc
+++ b/src/wasm-c.cc
@@ -239,14 +239,12 @@ wasm_config_t* wasm_config_new() {
 
 WASM_DEFINE_OWN(engine, Engine)
 
-wasm_engine_t* wasm_engine_new(int argc, const char *const argv[]) {
-  return release(Engine::make(argc, argv));
+wasm_engine_t* wasm_engine_new() {
+  return release(Engine::make());
 }
 
-wasm_engine_t* wasm_engine_new_with_config(
-  int argc, const char *const argv[], wasm_config_t* config
-) {
-  return release(Engine::make(argc, argv, adopt(config)));
+wasm_engine_t* wasm_engine_new_with_config(wasm_config_t* config) {
+  return release(Engine::make(adopt(config)));
 }
 
 

--- a/src/wasm-v8.cc
+++ b/src/wasm-v8.cc
@@ -274,16 +274,14 @@ void Engine::operator delete(void *p) {
   ::operator delete(p);
 }
 
-auto Engine::make(
-  int argc, const char *const argv[], own<Config*>&& config
-) -> own<Engine*> {
+auto Engine::make(own<Config*>&& config) -> own<Engine*> {
   v8::internal::FLAG_expose_gc = true;
   v8::internal::FLAG_experimental_wasm_mut_global = true;
-  v8::V8::SetFlagsFromCommandLine(&argc, const_cast<char**>(argv), false);
+  // v8::V8::SetFlagsFromCommandLine(&argc, const_cast<char**>(argv), false);
   auto engine = new(std::nothrow) EngineImpl;
   if (!engine) return own<Engine*>();
   // v8::V8::InitializeICUDefaultLocation(argv[0]);
-  v8::V8::InitializeExternalStartupData(argv[0]);
+  // v8::V8::InitializeExternalStartupData(argv[0]);
   engine->platform = v8::platform::NewDefaultPlatform();
   v8::V8::InitializePlatform(engine->platform.get());
   v8::V8::Initialize();


### PR DESCRIPTION
Now that we include the snapshot into the code, command parameters are no longer needed. Dropping them from Engine::make in the hope that other VMs don't need them either.