### PR TITLE
Add make command to display V8 build configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,12 @@ v8-clean:
 	echo >${V8_OUT}/version ${V8_VERSION}
 
 
+# Display V8 build configuration
+.PHONY: v8-gn-args
+v8-gn-args:
+	@echo ${V8_GN_ARGS}
+
+
 ###############################################################################
 # Docker
 #


### PR DESCRIPTION
This PR adds `make v8-gn-args` command that prints the value of `V8_GN_ARGS` variable. My intended use is as follows:
```
export V8_GN_ARGS="clang_base_path=\\\"$CCACHE_CLANG_DIR\\\" $(make v8-gn-args)"
make V8_GN_ARGS="$V8_GN_ARGS" v8
```
where `CCACHE_CLANG_DIR` points to `ccache`-enabled `clang` symlinks.