### PR TITLE
Fix warnings, compile examples with -Wall -Werror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,11 +113,11 @@ run-%-cc: ${EXAMPLE_OUT}/%-cc ${EXAMPLE_OUT}/%.wasm ${V8_BLOBS:%=${EXAMPLE_OUT}/
 # Compiling C / C++ example
 ${EXAMPLE_OUT}/%-c.o: ${EXAMPLE_DIR}/%.c ${WASM_INCLUDE}/wasm.h
 	mkdir -p ${EXAMPLE_OUT}
-	${C_COMP} -Wno-unused -c ${C_FLAGS} -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} $< -o $@
+	${C_COMP} -c ${C_FLAGS} -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} $< -o $@
 
 ${EXAMPLE_OUT}/%-cc.o: ${EXAMPLE_DIR}/%.cc ${WASM_INCLUDE}/wasm.hh
 	mkdir -p ${EXAMPLE_OUT}
-	${CC_COMP} -Wno-unused -c -std=c++11 ${CC_FLAGS} -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} $< -o $@
+	${CC_COMP} -c -std=c++11 ${CC_FLAGS} -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} $< -o $@
 
 # Linking C / C++ example
 .PRECIOUS: ${EXAMPLES:%=${EXAMPLE_OUT}/%-c}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ V8_ARCH = x64
 V8_MODE = release
 
 WASM_FLAGS = -DDEBUG  # -DDEBUG_LOG
-C_FLAGS = ${WASM_FLAGS} -ggdb -O0 -fsanitize=address
+C_FLAGS = ${WASM_FLAGS} -ggdb -O -fsanitize=address
 CC_FLAGS = ${C_FLAGS}
 LD_FLAGS = -fsanitize-memory-track-origins -fsanitize-memory-use-after-dtor
 
@@ -113,11 +113,11 @@ run-%-cc: ${EXAMPLE_OUT}/%-cc ${EXAMPLE_OUT}/%.wasm ${V8_BLOBS:%=${EXAMPLE_OUT}/
 # Compiling C / C++ example
 ${EXAMPLE_OUT}/%-c.o: ${EXAMPLE_DIR}/%.c ${WASM_INCLUDE}/wasm.h
 	mkdir -p ${EXAMPLE_OUT}
-	${C_COMP} -c -std=c11 ${C_FLAGS} -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} $< -o $@
+	${C_COMP} -Wall -Werror -Wno-unused -c ${C_FLAGS} -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} $< -o $@
 
 ${EXAMPLE_OUT}/%-cc.o: ${EXAMPLE_DIR}/%.cc ${WASM_INCLUDE}/wasm.hh
 	mkdir -p ${EXAMPLE_OUT}
-	${CC_COMP} -c -std=c++11 ${CC_FLAGS} -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} $< -o $@
+	${CC_COMP} -Wall -Werror -Wno-unused -c -std=c++11 ${CC_FLAGS} -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} $< -o $@
 
 # Linking C / C++ example
 .PRECIOUS: ${EXAMPLES:%=${EXAMPLE_OUT}/%-c}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ V8_ARCH = x64
 V8_MODE = release
 
 WASM_FLAGS = -DDEBUG  # -DDEBUG_LOG
-C_FLAGS = ${WASM_FLAGS} -ggdb -O -fsanitize=address
+C_FLAGS = ${WASM_FLAGS} -Wall -Werror -ggdb -O -fsanitize=address
 CC_FLAGS = ${C_FLAGS}
 LD_FLAGS = -fsanitize-memory-track-origins -fsanitize-memory-use-after-dtor
 
@@ -113,11 +113,11 @@ run-%-cc: ${EXAMPLE_OUT}/%-cc ${EXAMPLE_OUT}/%.wasm ${V8_BLOBS:%=${EXAMPLE_OUT}/
 # Compiling C / C++ example
 ${EXAMPLE_OUT}/%-c.o: ${EXAMPLE_DIR}/%.c ${WASM_INCLUDE}/wasm.h
 	mkdir -p ${EXAMPLE_OUT}
-	${C_COMP} -Wall -Werror -Wno-unused -c ${C_FLAGS} -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} $< -o $@
+	${C_COMP} -Wno-unused -c ${C_FLAGS} -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} $< -o $@
 
 ${EXAMPLE_OUT}/%-cc.o: ${EXAMPLE_DIR}/%.cc ${WASM_INCLUDE}/wasm.hh
 	mkdir -p ${EXAMPLE_OUT}
-	${CC_COMP} -Wall -Werror -Wno-unused -c -std=c++11 ${CC_FLAGS} -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} $< -o $@
+	${CC_COMP} -Wno-unused -c -std=c++11 ${CC_FLAGS} -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} $< -o $@
 
 # Linking C / C++ example
 .PRECIOUS: ${EXAMPLES:%=${EXAMPLE_OUT}/%-c}

--- a/example/callback.c
+++ b/example/callback.c
@@ -78,7 +78,7 @@ int main(int argc, const char* argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  if(fread(binary.data, file_size, 1, file) != 1) {
+  if (fread(binary.data, file_size, 1, file) != 1) {
     printf("> Error loading module!\n");
     return 1;
   }

--- a/example/callback.c
+++ b/example/callback.c
@@ -78,7 +78,10 @@ int main(int argc, const char* argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  fread(binary.data, file_size, 1, file);
+  if(fread(binary.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
   fclose(file);
 
   // Compile.

--- a/example/global.c
+++ b/example/global.c
@@ -73,7 +73,7 @@ int main(int argc, const char* argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  if(fread(binary.data, file_size, 1, file) != 1) {
+  if (fread(binary.data, file_size, 1, file) != 1) {
     printf("> Error loading module!\n");
     return 1;
   }

--- a/example/global.c
+++ b/example/global.c
@@ -73,7 +73,10 @@ int main(int argc, const char* argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  fread(binary.data, file_size, 1, file);
+  if(fread(binary.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
   fclose(file);
 
   // Compile.

--- a/example/hello.c
+++ b/example/hello.c
@@ -35,7 +35,7 @@ int main(int argc, const char* argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  if(fread(binary.data, file_size, 1, file) != 1) {
+  if (fread(binary.data, file_size, 1, file) != 1) {
     printf("> Error loading module!\n");
     return 1;
   }

--- a/example/hello.c
+++ b/example/hello.c
@@ -35,7 +35,10 @@ int main(int argc, const char* argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  fread(binary.data, file_size, 1, file);
+  if(fread(binary.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
   fclose(file);
 
   // Compile.

--- a/example/memory.c
+++ b/example/memory.c
@@ -114,7 +114,7 @@ int main(int argc, const char* argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  if(fread(binary.data, file_size, 1, file) != 1) {
+  if (fread(binary.data, file_size, 1, file) != 1) {
     printf("> Error loading module!\n");
     return 1;
   }

--- a/example/memory.c
+++ b/example/memory.c
@@ -114,7 +114,10 @@ int main(int argc, const char* argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  fread(binary.data, file_size, 1, file);
+  if(fread(binary.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
   fclose(file);
 
   // Compile.

--- a/example/reflect.c
+++ b/example/reflect.c
@@ -96,7 +96,7 @@ int main(int argc, const char* argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  if(fread(binary.data, file_size, 1, file) != 1) {
+  if (fread(binary.data, file_size, 1, file) != 1) {
     printf("> Error loading module!\n");
     return 1;
   }

--- a/example/reflect.c
+++ b/example/reflect.c
@@ -96,7 +96,10 @@ int main(int argc, const char* argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  fread(binary.data, file_size, 1, file);
+  if(fread(binary.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
   fclose(file);
 
   // Compile.

--- a/example/serialize.c
+++ b/example/serialize.c
@@ -33,7 +33,10 @@ int main(int argc, const char* argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  fread(binary.data, file_size, 1, file);
+  if(fread(binary.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
   fclose(file);
 
   // Compile.

--- a/example/serialize.c
+++ b/example/serialize.c
@@ -33,7 +33,7 @@ int main(int argc, const char* argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  if(fread(binary.data, file_size, 1, file) != 1) {
+  if (fread(binary.data, file_size, 1, file) != 1) {
     printf("> Error loading module!\n");
     return 1;
   }

--- a/example/table.c
+++ b/example/table.c
@@ -92,7 +92,7 @@ int main(int argc, const char* argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  if(fread(binary.data, file_size, 1, file) != 1) {
+  if (fread(binary.data, file_size, 1, file) != 1) {
     printf("> Error loading module!\n");
     return 1;
   }

--- a/example/table.c
+++ b/example/table.c
@@ -92,7 +92,10 @@ int main(int argc, const char* argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  fread(binary.data, file_size, 1, file);
+  if(fread(binary.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
   fclose(file);
 
   // Compile.

--- a/example/threads.c
+++ b/example/threads.c
@@ -106,7 +106,7 @@ int main(int argc, const char *argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  if(fread(binary.data, file_size, 1, file) != 1) {
+  if (fread(binary.data, file_size, 1, file) != 1) {
     printf("> Error loading module!\n");
     return 1;
   }

--- a/example/threads.c
+++ b/example/threads.c
@@ -106,7 +106,10 @@ int main(int argc, const char *argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  fread(binary.data, file_size, 1, file);
+  if(fread(binary.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
   fclose(file);
 
   // Compile and share.

--- a/example/threads.cc
+++ b/example/threads.cc
@@ -31,7 +31,7 @@ void run(
   // Obtain.
   auto module = wasm::Module::obtain(store, shared);
   if (!module) {
-    std::lock_guard<std::mutex>(*mutex);
+    std::lock_guard<std::mutex> lock(*mutex);
     std::cout << "> Error compiling module!" << std::endl;
     return;
   }
@@ -56,7 +56,7 @@ void run(
     wasm::Extern* imports[] = {func.get(), global.get()};
     auto instance = wasm::Instance::make(store, module.get(), imports);
     if (!instance) {
-      std::lock_guard<std::mutex>(*mutex);
+      std::lock_guard<std::mutex> lock(*mutex);
       std::cout << "> Error instantiating module!" << std::endl;
       return;
     }
@@ -64,7 +64,7 @@ void run(
     // Extract export.
     auto exports = instance->exports();
     if (exports.size() == 0 || exports[0]->kind() != wasm::EXTERN_FUNC || !exports[0]->func()) {
-      std::lock_guard<std::mutex>(*mutex);
+      std::lock_guard<std::mutex> lock(*mutex);
       std::cout << "> Error accessing export!" << std::endl;
       return;
     }
@@ -106,7 +106,7 @@ int main(int argc, const char *argv[]) {
   std::thread threads[N_THREADS];
   for (int i = 0; i < N_THREADS; ++i) {
     {
-      std::lock_guard<std::mutex>(*mutex);
+      std::lock_guard<std::mutex> lock(mutex);
       std::cout << "Initializing thread " << i << "..." << std::endl;
     }
     threads[i] = std::thread(run, engine.get(), shared.get(), &mutex, i);
@@ -114,7 +114,7 @@ int main(int argc, const char *argv[]) {
 
   for (int i = 0; i < N_THREADS; ++i) {
     {
-      std::lock_guard<std::mutex>(*mutex);
+      std::lock_guard<std::mutex> lock(mutex);
       std::cout << "Waiting for thread " << i << "..." << std::endl;
     }
     threads[i].join();

--- a/example/trap.c
+++ b/example/trap.c
@@ -38,7 +38,7 @@ int main(int argc, const char* argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  if(fread(binary.data, file_size, 1, file) != 1) {
+  if (fread(binary.data, file_size, 1, file) != 1) {
     printf("> Error loading module!\n");
     return 1;
   }

--- a/example/trap.c
+++ b/example/trap.c
@@ -38,7 +38,10 @@ int main(int argc, const char* argv[]) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t binary;
   wasm_byte_vec_new_uninitialized(&binary, file_size);
-  fread(binary.data, file_size, 1, file);
+  if(fread(binary.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
   fclose(file);
 
   // Compile.

--- a/src/wasm-v8.cc
+++ b/src/wasm-v8.cc
@@ -1419,7 +1419,7 @@ void Shared<Module>::operator delete(void* p) {
 }
 
 auto Module::share() const -> own<Shared<Module>*> {
-  auto shared = seal<Shared<Module>>(new vec<byte_t>(std::move(serialize())));
+  auto shared = seal<Shared<Module>>(new vec<byte_t>(serialize()));
   stats.make(Stats::MODULE, shared, Stats::SHARED);
   return make_own(shared);
 }

--- a/src/wasm-v8.cc
+++ b/src/wasm-v8.cc
@@ -988,7 +988,6 @@ auto memorytype_to_v8(
   StoreImpl* store, const MemoryType* type
 ) -> v8::Local<v8::Object> {
   auto isolate = store->isolate();
-  auto context = store->context();
   auto desc = v8::Object::New(isolate);
   limits_to_v8(store, type->limits(), desc);
   return desc;
@@ -1693,7 +1692,6 @@ void FuncData::v8_callback(const v8::FunctionCallbackInfo<v8::Value>& info) {
   auto isolate = store->isolate();
   v8::HandleScope handle_scope(isolate);
 
-  auto context = store->context();
   auto& param_types = self->type->params();
   auto& result_types = self->type->results();
 


### PR DESCRIPTION
Would also be nice to compile the library with `-Wall -Werror`

* Change from `-O0` to `-O`. `-O0` triggered `_FORTIFY_SOURCE requires compiling with optimization` warning in `glibc`
* Use `-Wall -Werror -Wno-unused` when compiling examples
* Remove `-std=c11` since made `usleep` unavailable

```
example/threads.c:38:5: warning: implicit declaration of function 'usleep' is invalid in C99 [-Wimplicit-function-declaration]
    usleep(100000);
    ^
```