### PR TITLE
Don't touch source files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,8 @@ ${WASM_OUT}/%.o: ${WASM_SRC}/%.cc ${WASM_INCLUDE}/wasm.h ${WASM_INCLUDE}/wasm.hh
 	mkdir -p ${WASM_OUT}
 	${CC_COMP} -c -std=c++11 ${CC_FLAGS} -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} -I${WASM_SRC} $< -o $@
 
-${WASM_SRC}/wasm-c.cc: ${WASM_SRC}/wasm-v8.cc
+# wasm-c.cc includes wasm-v8.cc, so set up a side dependency
+${WASM_OUT}/wasm-c.o: ${WASM_SRC}/wasm-v8.cc
 
 
 ###############################################################################

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,6 @@ ${WASM_OUT}/%.o: ${WASM_SRC}/%.cc ${WASM_INCLUDE}/wasm.h ${WASM_INCLUDE}/wasm.hh
 	${CC_COMP} -c -std=c++11 ${CC_FLAGS} -I. -I${V8_INCLUDE} -I${WASM_INCLUDE} -I${WASM_SRC} $< -o $@
 
 ${WASM_SRC}/wasm-c.cc: ${WASM_SRC}/wasm-v8.cc
-	touch $@
 
 
 ###############################################################################


### PR DESCRIPTION
It is okay in makefiles to establish dependencies between source files, but touching them has nasty consequences like `emacs` complaining that the file has changed etc.

Maybe it should be verified why the dependency is needed at all.